### PR TITLE
MacOS serielle Treiber ohne Signatur

### DIFF
--- a/BeginnersGuide/Guide.md
+++ b/BeginnersGuide/Guide.md
@@ -17,6 +17,8 @@ CH340G Bridge Treiber
 
 Nach der Installation der Treiber Rechner neustarten.
 
+Bemerkung für MacOS 10.9 oder neuer: Wenn ein nicht-signierter Treiber installiert wird, muss dies in MacOS explizit erlaubt werden. Eine gute Beschreibung gibt es bei [tzapu.com](https://tzapu.com/making-ch340-ch341-serial-adapters-work-under-el-capitan-os-x/)
+
 ## Board Manager installieren
 Die Arduino IDE 1.6.5 runterladen & installieren: 
 https://www.arduino.cc/en/Main/OldSoftwareReleases#previous


### PR DESCRIPTION
Nachdem ich 2 Abende brauchte, um den seriellen Treiber unter MacOS El Capitan zum Laufen zu bringen, habe ich die hilfreiche Beschreibung zum BeginnersGuide hinzugefügt. 