### PR TITLE
Fixes #63: Use platformio for enhanced command line development

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "arduino/libs/SHT1x"]
 	path = arduino/libs/SHT1x
 	url = https://github.com/practicalarduino/SHT1x
+
+[submodule "esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/lib/TinyGPSPlus"]
+	path = esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/lib/TinyGPSPlus
+	url = https://github.com/mikalhart/TinyGPSPlus.git

--- a/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/.gitignore
+++ b/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/.gitignore
@@ -1,0 +1,7 @@
+.pioenvs
+.piolibdeps
+examples
+keywords.txt
+library.json
+TinyGPS++.cpp
+TinyGPS++.h

--- a/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/lib/readme.txt
+++ b/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/lib/readme.txt
@@ -1,0 +1,36 @@
+
+This directory is intended for the project specific (private) libraries.
+PlatformIO will compile them to static libraries and link to executable file.
+
+The source code of each library should be placed in separate directory, like
+"lib/private_lib/[here are source files]".
+
+For example, see how can be organized `Foo` and `Bar` libraries:
+
+|--lib
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |- readme.txt --> THIS FILE
+|- platformio.ini
+|--src
+   |- main.c
+
+Then in `src/main.c` you should use:
+
+#include <Foo.h>
+#include <Bar.h>
+
+// rest H/C/CPP code
+
+PlatformIO will find your libraries automatically, configure preprocessor's
+include paths and build them.
+
+More information about PlatformIO Library Dependency Finder
+- http://docs.platformio.org/page/librarymanager/ldf.html

--- a/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/platformio.ini
+++ b/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/platformio.ini
@@ -1,0 +1,44 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[common]
+build_flags =
+; Always depend on specific library versions (wherever possible)
+; Keep Library names in alphabetical order
+; ESP8266WiFi in both cases is necessary to solve a case sensitivity issue with WiFiUdp.h
+; TinyGPSPlus is not yet in platformio - https://github.com/platformio/platformio-libmirror/issues/99
+lib_deps_external =
+  Adafruit BME280 Library@1.0.4
+  Adafruit BMP085 Library@1.0.0
+  ArduinoJson@5.8.4
+  DHT sensor library@1.3.0
+  DNSServer
+  ESP8266HTTPClient
+  ESP8266WebServer
+  ESP8266WiFi
+  ESP8266_SSD1306
+  ESP8266httpUpdate
+  ESP8266mDNS
+  EspSoftwareSerial
+  SPI
+  Ticker
+  TinyGPSPlus
+  WifiManager@0.12
+  Wire
+
+[env:nodemcuv2]
+platform = espressif8266
+framework = arduino
+board = nodemcuv2
+build_flags = ${common.build_flags}
+lib_deps = ${common.lib_deps_external}


### PR DESCRIPTION
With this setup, you can 
* clone the repository
* go to the directory esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht
* build the software with "pio run"
* build and upload the software with "pio -t upload"

If the PR is accepted, I would write another enhancement for the documentation as well.

I had to add a gitmodule reference to TinyGPSPlus which can be removed whenever https://github.com/platformio/platformio-libmirror/issues/99 is resolved.