### PR TITLE
Check if credentials are not empty for basic auth

### DIFF
--- a/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/ppd42ns-wificonfig-ppd-sds-dht.ino
+++ b/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/ppd42ns-wificonfig-ppd-sds-dht.ino
@@ -725,8 +725,17 @@ void writeConfig() {
 /* Base64 encode user:password                                   *
 /*****************************************************************/
 void create_basic_auth_strings() {
-	basic_auth_custom = base64::encode(String(user_custom)+":"+String(pwd_custom));
-	basic_auth_influxdb = base64::encode(String(user_influxdb)+":"+String(pwd_influxdb));
+	if (strcmp(user_custom, "") == 0 && strcmp(pwd_custom, "") == 0) {
+		basic_auth_custom = "";
+	} else {
+		basic_auth_custom = base64::encode(String(user_custom)+":"+String(pwd_custom));
+	}
+	
+	if (strcmp(user_influxb, "") == 0 && strcmp(pwd_influxdb, "") == 0) {
+		basic_auth_influxdb = "";
+	} else {
+		basic_auth_influxdb = base64::encode(String(user_influxdb)+":"+String(pwd_influxdb));
+	}
 }
 
 /*****************************************************************


### PR DESCRIPTION
Set basic auth string empty, if credentials are empty, otherwise https://github.com/opendata-stuttgart/sensors-software/blob/master/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/ppd42ns-wificonfig-ppd-sds-dht.ino#L1318 will fail, because basic_auth_custom or basic_auth_influxdb contains a base64 encoded :