### PR TITLE
Change send to openSenseMap placeholder to empty string

### DIFF
--- a/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/ext_def.h
+++ b/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/ext_def.h
@@ -25,7 +25,7 @@
 #define NTP_SERVER "0.europe.pool.ntp.org"
 
 // OpenSenseMap
-#define SENSEBOXID "00112233445566778899aabb"
+#define SENSEBOXID ""
 
 // Definition eigene API
 #define HOST_CUSTOM "192.168.234.1"

--- a/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/platformio.ini
+++ b/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/platformio.ini
@@ -32,10 +32,10 @@ lib_deps_external =
   EspSoftwareSerial
   SPI
   Ticker
-  TinyGPSPlus
+  mikalhart/TinyGPSPlus#88c9db5c7491a2877bdd29edac6f8fff40862215
   WifiManager@0.12
   Wire
-extra_script = platformio_script.py  
+extra_script = platformio_script.py
 
 [env:nodemcuv2]
 lang = DE

--- a/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/ppd42ns-wificonfig-ppd-sds-dht.ino
+++ b/esp8266-arduino/ppd42ns-wificonfig-ppd-sds-dht/ppd42ns-wificonfig-ppd-sds-dht.ino
@@ -138,10 +138,10 @@ const char* host_dusti = "api.luftdaten.info";
 const char* url_dusti = "/v1/push-sensor-data/";
 int httpPort_dusti = 443;
 
-const char* host_sensemap = "api.opensensemap.org";
+const char* host_sensemap = "ingress.opensensemap.org";
 String url_sensemap = "/boxes/BOXID/data?luftdaten=1";
 const int httpPort_sensemap = 443;
-char senseboxid[30] = "00112233445566778899aabb";
+char senseboxid[30] = "";
 
 char host_influxdb[100] = "api.luftdaten.info";
 char url_influxdb[100] = "/write?db=luftdaten";


### PR DESCRIPTION
This pull request sets the placeholder for the senseBox Id in the configuration interface to an empty string. The previous value `00112233445566778899aabb` was causing some irritations wether there was some more steps involved or not.

Also, the sending domain is changed to `ingress.opensensemap.org`