### PR TITLE
Get available network via additional request

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1004,7 +1004,7 @@ void webserver_config() {
 		page_content += form_submit(FPSTR(INTL_SPEICHERN));
 		page_content += F("</table><br/>");
 		page_content += F("<br/></form>");
-		page_content += "<script>var x=new XMLHttpRequest();x.open('GET','/wifi');x.onload = function(){if (x.status === 200) {document.getElementById('wifilist').innerHtml = xhr.responseText;}};r.send();</script>";
+		page_content += "<script>var x=new XMLHttpRequest();x.open('GET','/wifi');x.onload = function(){if (x.status === 200) {document.getElementById('wifilist').innerHTML = x.responseText;}};x.send();</script>";
 	} else {
 
 #define readCharParam(param) if (server.hasArg(#param)){ server.arg(#param).toCharArray(param, sizeof(param)); }


### PR DESCRIPTION
This is just an idea for speedup and more stable loading of config page.
## The problem
I noticed that in some situation it is very hard to open config page. I found that the problem persist when available network are mode then 40-45. In that situation, config page make very big output and output process fail. Make some test and confirm that the problem disappears when limit network to 30 or move to in a "quieter" place.

## The Solutions
So, I suggest **two solutions**:

**First:** (in this pull request) contains move logic for getting available WiFi network to independent reqest witch is called from config page via ajax. In this case, config page contains only static form and load very quickly. WiFi list comes after a second. 
If you think the decision is appropriate, I can optimize it more. Addition - we can add extra button that will call list of available Wifi network on click. This can be available in both mode - before first configuration and on normal work. 

**Second solution:** If you think the change is not appropriate, than I suggest just to limit list of available network to (for example) **30 network**. The list is ordered by signal strength, so it is normal you network to be in first 30 network. In current city environment it is a common occurrence to have more than 60 available networks in one place.

Best