### PR TITLE
Support for the BMP280 (temperature + pressure) sensor

### DIFF
--- a/airrohr-firmware/Readme.md
+++ b/airrohr-firmware/Readme.md
@@ -51,6 +51,7 @@ Installierbar über Arduino IDE (Menü Sketch -> Bibliothek einbinden -> Bibliot
 * [ArduinoJson](https://github.com/bblanchon/ArduinoJson) (5.10.1) (MIT)
 * [Adafruit Unified Sensor](https://github.com/adafruit/Adafruit_Sensor) (1.0.2) (Apache)
 * [Adafruit BMP085 library](https://github.com/adafruit/Adafruit-BMP085-Library) (1.0.0) (BSD)
+* [Adafruit BMP280 library](https://github.com/adafruit/Adafruit_BMP280_Library) (1.0.2) (BSD)
 * [Adafruit BME280 library](https://github.com/adafruit/Adafruit_BME280_Library) (1.0.5) (BSD)
 * [DHT sensor library](https://github.com/adafruit/DHT-sensor-library) (1.3.0) (MIT)
 * [ESP8266 and ESP32 Oled driver for SSD1306 display](https://github.com/squix78/esp8266-oled-ssd1306) (3.2.7) (MIT)
@@ -100,6 +101,7 @@ Diese Firmware definiert die Pins für die verschiedenenen Sensoren wie folgt:
 * DHT22 => Pin 7
 * SDS011 => Pin 1
 * BMP180 => Pin 3
+* BMP280 => Pin 3
 * BME280 => Pin 11
 * GPS(Neo-6M) => Pin 9
 
@@ -120,6 +122,7 @@ Installierbar über Arduino IDE (für Versionen siehe auch ESP8266):
 * [ArduinoJson](https://github.com/bblanchon/ArduinoJson) (5.10.1) (MIT)
 * [Adafruit Unified Sensor](https://github.com/adafruit/Adafruit_Sensor) (1.0.2) (Apache)
 * [Adafruit BMP085 library](https://github.com/adafruit/Adafruit-BMP085-Library) (1.0.0) (BSD)
+* [Adafruit BMP280 library](https://github.com/adafruit/Adafruit_BMP280_Library) (1.0.2) (BSD)
 * [Adafruit BME280 library](https://github.com/adafruit/Adafruit_BME280_Library) (1.0.5) (BSD)
 * [DHT sensor library](https://github.com/adafruit/DHT-sensor-library) (1.3.0) (MIT)
 * [LiquidCrystal I2C](https://github.com/marcoschwartz/LiquidCrystal_I2C) (1.1.2)

--- a/airrohr-firmware/ext_def.h
+++ b/airrohr-firmware/ext_def.h
@@ -91,6 +91,14 @@
 #define BMP_PIN_SDA D3
 #endif
 
+// BMP280, Luftdruck-Sensor
+#define BMP280_READ 0
+#define BMP280_API_PIN 3
+#if defined(ESP8266)
+#define BMP280_PIN_SCL D4
+#define BMP280_PIN_SDA D3
+#endif
+
 // BME280, Luftdruck-Sensor
 #define BME280_READ 0
 #define BME280_API_PIN 11

--- a/airrohr-firmware/intl_bg.h
+++ b/airrohr-firmware/intl_bg.h
@@ -14,6 +14,7 @@ const char INTL_PPD42NS[] PROGMEM = "PPD42NS";
 const char INTL_DHT22[] PROGMEM = "DHT22";
 const char INTL_HTU21D[] PROGMEM = "HTU21D";
 const char INTL_BMP180[] PROGMEM = "BMP180";
+const char INTL_BMP280[] PROGMEM = "BMP280";
 const char INTL_BME280[] PROGMEM = "BME280";
 const char INTL_BASICAUTH[] PROGMEM = "Оторизация";
 const char INTL_WEITERE_EINSTELLUNGEN[] PROGMEM ="Още настройки";

--- a/airrohr-firmware/intl_de.h
+++ b/airrohr-firmware/intl_de.h
@@ -14,6 +14,7 @@ const char INTL_PPD42NS[] PROGMEM = "PPD42NS";
 const char INTL_DHT22[] PROGMEM = "DHT22 (Temperatur, rel. Luftfeuchte)";
 const char INTL_HTU21D[] PROGMEM = "HTU21D (Temperatur, rel. Luftfeuchte)";
 const char INTL_BMP180[] PROGMEM = "BMP180";
+const char INTL_BMP280[] PROGMEM = "BMP280";
 const char INTL_BME280[] PROGMEM = "BME280";
 const char INTL_BASICAUTH[] PROGMEM = "BasicAuth aktivieren";
 const char INTL_WEITERE_EINSTELLUNGEN[] PROGMEM ="Weitere Einstellungen";

--- a/airrohr-firmware/intl_en.h
+++ b/airrohr-firmware/intl_en.h
@@ -14,6 +14,7 @@ const char INTL_PPD42NS[] PROGMEM = "PPD42NS";
 const char INTL_DHT22[] PROGMEM = "DHT22 (temperature, rel. humidity)";
 const char INTL_HTU21D[] PROGMEM = "HTU21D (temperature, rel. humidity)";
 const char INTL_BMP180[] PROGMEM = "BMP180";
+const char INTL_BMP280[] PROGMEM = "BMP280";
 const char INTL_BME280[] PROGMEM = "BME280";
 const char INTL_BASICAUTH[] PROGMEM = "Authorization";
 const char INTL_WEITERE_EINSTELLUNGEN[] PROGMEM ="More settings";

--- a/airrohr-firmware/intl_es.h
+++ b/airrohr-firmware/intl_es.h
@@ -14,6 +14,7 @@ const char INTL_PPD42NS[] PROGMEM = "PPD42NS";
 const char INTL_DHT22[] PROGMEM = "DHT22";
 const char INTL_HTU21D[] PROGMEM = "HTU21D";
 const char INTL_BMP180[] PROGMEM = "BMP180";
+const char INTL_BMP280[] PROGMEM = "BMP280";
 const char INTL_BME280[] PROGMEM = "BME280";
 const char INTL_BASICAUTH[] PROGMEM = "Autorización";
 const char INTL_WEITERE_EINSTELLUNGEN[] PROGMEM ="Otras configruaciones";

--- a/airrohr-firmware/intl_fr.h
+++ b/airrohr-firmware/intl_fr.h
@@ -14,6 +14,7 @@ const char INTL_PPD42NS[] PROGMEM = "PPD42NS";
 const char INTL_DHT22[] PROGMEM = "DHT22";
 const char INTL_HTU21D[] PROGMEM = "HTU21D";
 const char INTL_BMP180[] PROGMEM = "BMP180";
+const char INTL_BMP280[] PROGMEM = "BMP280";
 const char INTL_BME280[] PROGMEM = "BME280";
 const char INTL_BASICAUTH[] PROGMEM = "Autorisation";
 const char INTL_WEITERE_EINSTELLUNGEN[] PROGMEM ="Autres paramètres";

--- a/airrohr-firmware/intl_it.h
+++ b/airrohr-firmware/intl_it.h
@@ -14,6 +14,7 @@ const char INTL_PPD42NS[] PROGMEM = "PPD42NS";
 const char INTL_DHT22[] PROGMEM = "DHT22 (temperatura, umidità relativa)";
 const char INTL_HTU21D[] PROGMEM = "HTU21D (temperatura, umidità relativa)";
 const char INTL_BMP180[] PROGMEM = "BMP180";
+const char INTL_BMP280[] PROGMEM = "BMP280";
 const char INTL_BME280[] PROGMEM = "BME280";
 const char INTL_BASICAUTH[] PROGMEM = "Autorizzazione";
 const char INTL_WEITERE_EINSTELLUNGEN[] PROGMEM ="Altre configurazioni";

--- a/airrohr-firmware/intl_nl.h
+++ b/airrohr-firmware/intl_nl.h
@@ -14,6 +14,7 @@ const char INTL_PPD42NS[] PROGMEM = "PPD42NS";
 const char INTL_DHT22[] PROGMEM = "DHT22 (temperatuur, rel. vochtigheid)";
 const char INTL_HTU21D[] PROGMEM = "HTU21D (temperatuur, rel. vochtigheid)";
 const char INTL_BMP180[] PROGMEM = "BMP180";
+const char INTL_BMP280[] PROGMEM = "BMP280";
 const char INTL_BME280[] PROGMEM = "BME280";
 const char INTL_BASICAUTH[] PROGMEM = "Authorisatie";
 const char INTL_WEITERE_EINSTELLUNGEN[] PROGMEM ="Meer instellingen";

--- a/airrohr-firmware/intl_template.h
+++ b/airrohr-firmware/intl_template.h
@@ -13,6 +13,7 @@ const char INTL_PPD42NS[] PROGMEM = "";
 const char INTL_DHT22[] PROGMEM = "";
 const char INTL_HTU21D[] PROGMEM = "";
 const char INTL_BMP180[] PROGMEM = "";
+const char INTL_BMP280[] PROGMEM = "";
 const char INTL_BME280[] PROGMEM = "";
 const char INTL_BASICAUTH[] PROGMEM = "";
 const char INTL_WEITERE_EINSTELLUNGEN[] PROGMEM ="";

--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -18,7 +18,8 @@ build_flags =
 ; ESP8266WiFi in both cases is necessary to solve a case sensitivity issue with WiFiUdp.h
 ; TinyGPSPlus is not yet in platformio - https://github.com/platformio/platformio-libmirror/issues/99
 lib_deps_external =
-  Adafruit BME280 Library@1.0.4
+  Adafruit BME280 Library@1.0.5
+  Adafruit BMP280 Library@1.0.2
   Adafruit BMP085 Library@1.0.0
   ArduinoJson@5.8.4
   DHT sensor library@1.3.0


### PR DESCRIPTION
The [FAQ on luftdaten.info](http://luftdaten.info/faq/#toggle-id-10) states that the BMP280 sensor is supported, while it actually isn't (yet).
As I bought a BMP280 for my luftdaten.info sensor, I took the liberty to implement support for it following the existing pattern for BMP085 and BME280.

Product:
https://www.adafruit.com/product/2651