### PR TITLE
korrekter Pin7 für DS18B20

### DIFF
--- a/airrohr-firmware/Readme.md
+++ b/airrohr-firmware/Readme.md
@@ -108,8 +108,9 @@ Beim Anschluss von Sensoren mit 5V bitte die Board-Version beachten. NodeMCU v3 
 
 ### DS18B20 (OneWire interface)
 Please check your version (pinout) at [https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf]
+Uses the same PIN D7 as DHT22, so DHT22 OR DS18B20 can be used. 
 * GND  -> Pin GND
-* DQ   -> Pin D6 (GPIO 13)
+* DQ   -> Pin D7 (GPIO 13)
 * VCC  -> Pin 3V3 or Pin VU
 
 ### PMS1003 to PMS6003


### PR DESCRIPTION
DS18B20 war als Pin 6 (GPIO13) angegeben.
Korrekt ist jedoch PIN7 (GPIO13) 
+ Hinweis bei DS18B20, dass nur jeweils entweder DHT22 ODER DS18B20 genutzt werden kann.