### PR TITLE
changed: wiring RX/TX for GPS Neo 6m

### DIFF
--- a/airrohr-firmware/Readme.md
+++ b/airrohr-firmware/Readme.md
@@ -165,9 +165,10 @@ Pinout PMS7003:
 * SDA  ->  Pin D3 (GPIO0)
 
 ### GPS NEO 6M (seriell)
-Strom und Masse vom Board.
-* RX-Pin vom NEO an D5
-* TX-Pin vom NEO an D6
+Strom und Masse vom Board. (GND und üblicherweise 3,3v, vorher prüfen/Anleitung, Beschreibung GPS!) 
+TX (senden) und RX (empfangen) werden gekreuzt verkabelt! 
+* TX von Neo -> Pin D5 (RX) 
+* RX von Neo -> Pin D6 (TX) 
 
 
 ### Luftdaten.info API "Pins"


### PR DESCRIPTION
corrected: wrong wiring description. TX/RX must be crossed.