### PR TITLE
Fix for PlatformIO's library selection causing build to fail.

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -29,7 +29,7 @@ lib_deps_external =
   ESP8266HTTPClient
   ESP8266WebServer
   ESP8266WiFi
-  ESP8266_SSD1306
+  ESP8266_SSD1306@3.2.7
   ESP8266httpUpdate
   ESP8266mDNS
   EspSoftwareSerial


### PR DESCRIPTION
Force use of library ESP8266_SSD1306@3.2.7 in platformio.ini.
Otherwise the builds fail.