### PR TITLE
Update library versions in platformio.ini

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -19,29 +19,29 @@ build_flags =
 ; TinyGPSPlus is not yet in platformio - https://github.com/platformio/platformio-libmirror/issues/99
 lib_deps_external =
   Adafruit Unified Sensor@1.0.2
-  Adafruit BME280 Library@1.0.6
+  Adafruit BME280 Library@1.0.7
   Adafruit BMP280 Library@1.0.2
   Adafruit BMP085 Library@1.0.0
   Adafruit HTU21DF Library@1.0.1
-  ArduinoJson@5.8.4
-  DHT sensor library@1.3.0
+  ArduinoJson@5.13.1
+  https://github.com/adafruit/DHT-sensor-library.git#1.1.1
   OneWire@2.3.2
-  DallasTemperature@3.7.7
+  DallasTemperature@3.8.0
   DNSServer
   ESP8266HTTPClient
   ESP8266WebServer
   ESP8266WiFi
-  ESP8266_SSD1306@3.2.7
+  ESP8266_SSD1306@4.0.0
   ESP8266httpUpdate
   ESP8266mDNS
   EspSoftwareSerial
-  OneWire
+  OneWire@2.3.4
   SPI
   Ticker
   mikalhart/TinyGPSPlus#88c9db5c7491a2877bdd29edac6f8fff40862215
   WifiManager@0.12
   Wire
-  LiquidCrystal_I2C
+  LiquidCrystal_I2C@1.1.2
 extra_scripts = platformio_script.py
 
 [env:nodemcuv2]


### PR DESCRIPTION
This patch updates library versions in platformio.ini to match the versions mentioned in Readme.md, as discussed in #221

For the Adafruit DHT sensor library, this patch takes special care to use the 1.1.1 version from github instead of the latest which is apparently known to have issues.

For readability, I did not re-order the list of libraries alphabetically yet.

The sensor firmware compiles with this patch, I have not tested it on actual hardware.