### PR TITLE
Update platformio library dependencies

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -24,8 +24,6 @@ lib_deps_external =
   Adafruit BMP085 Library@1.0.0
   Adafruit HTU21DF Library@1.0.1
   ArduinoJson@5.13.1
-  https://github.com/adafruit/DHT-sensor-library.git#1.1.1
-  OneWire@2.3.2
   DallasTemperature@3.8.0
   DNSServer
   ESP8266HTTPClient
@@ -38,8 +36,8 @@ lib_deps_external =
   OneWire@2.3.4
   SPI
   Ticker
-  mikalhart/TinyGPSPlus#88c9db5c7491a2877bdd29edac6f8fff40862215
-  WifiManager@0.12
+  mikalhart/TinyGPSPlus#v0.95
+  WifiManager
   Wire
   LiquidCrystal_I2C@1.1.2
 extra_scripts = platformio_script.py


### PR DESCRIPTION
This is another round of platformio updates, further synchronizing the platformio library dependencies with the libraries mentioned in sensors-sofrware airrohr-firmware/Readme.md

Changes:
* remove DHT dependency, source code of a known good DHT library is now included explicitly
* remove duplicate OneWire dependency
* set TinyGPSPlus version to 0.95 instead of a specific git revision
* remove explicit version of WifiManager and follow main stream (no version is mentioned in Readme.md)