### PR TITLE
Initialize indices array with constant value. 

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1501,7 +1501,7 @@ void webserver_wifi() {
 		page_content += FPSTR(INTL_NETZWERKE_GEFUNDEN);
 		page_content += String(count_wifiInfo);
 		page_content += F("<br/>");
-		int indices[count_wifiInfo];
+		int* indices= new int[count_wifiInfo];
 		debug_out(F("output config page 2"), DEBUG_MIN_INFO, 1);
 		for (int i = 0; i < count_wifiInfo; i++) {
 			indices[i] = i;
@@ -1536,6 +1536,7 @@ void webserver_wifi() {
 			page_content += wlan_ssid_to_table_row(wifiInfo[indices[i]].ssid, ((wifiInfo[indices[i]].encryptionType == ENC_TYPE_NONE) ? " " : "*"), wifiInfo[indices[i]].RSSI);
 		}
 		page_content += F("</table><br/><br/>");
+		delete[] indices;
 	}
 	server.send(200, FPSTR(TXT_CONTENT_TYPE_TEXT_HTML), page_content);
 }


### PR DESCRIPTION
Prevents "expression must have a constant value" in some IDEs. Fixes opendata-stuttgart/sensors-software#251