### PR TITLE
Update platformio configuration: add common build flags

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -13,6 +13,9 @@ src_dir = .
 
 [common]
 build_flags =
+  -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
+  -DVTABLES_IN_FLASH
+  -DNDEBUG
 ; Always depend on specific library versions (wherever possible)
 ; Keep Library names in alphabetical order
 ; ESP8266WiFi in both cases is necessary to solve a case sensitivity issue with WiFiUdp.h


### PR DESCRIPTION
This change updates the common build flags for the platformio build platform to match the description for settings in the Arduino IDE, specifically:
    * select low memory lwip2 library
    * vtables in flash
    * no debug output

