### PR TITLE
Don't call the expensive millis() function more often then needed

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -3613,8 +3613,8 @@ void setup() {
 
 	starttime = millis();                                   // store the start time
 	uptime = starttime;
-	starttime_SDS = millis();
-	next_display_millis = millis() + 5000;
+	starttime_SDS = starttime;
+	next_display_millis = starttime + 5000;
 }
 
 /*****************************************************************


### PR DESCRIPTION
Also shrinks the firmware by 16 bytes