### PR TITLE
Replace the "*" with a unicode padlock

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1577,7 +1577,7 @@ void webserver_wifi() {
 				continue;
 			}
 			// Print SSID and RSSI for each network found
-			page_content += wlan_ssid_to_table_row(wifiInfo[indices[i]].ssid, ((wifiInfo[indices[i]].encryptionType == ENC_TYPE_NONE) ? " " : "*"), wifiInfo[indices[i]].RSSI);
+			page_content += wlan_ssid_to_table_row(wifiInfo[indices[i]].ssid, ((wifiInfo[indices[i]].encryptionType == ENC_TYPE_NONE) ? " " : u8"🔒"), wifiInfo[indices[i]].RSSI);
 		}
 		page_content += F("</table><br/><br/>");
 	}


### PR DESCRIPTION
I didn't knew what to make of the "*". I only understood it after reading the
source.