### PR TITLE
link to the secure version of these two sites.

### DIFF
--- a/airrohr-firmware/html-content.h
+++ b/airrohr-firmware/html-content.h
@@ -62,11 +62,11 @@ const char TABLE_TAG_CLOSE_BR[] PROGMEM = "</table>";
 const char EMPTY_ROW[] PROGMEM = "<tr><td colspan='3'>&nbsp;</td></tr>";
 
 const char WEB_PAGE_FOOTER[] PROGMEM = "<br/><br/><a href='/' style='display:inline;'>{t}</a><br/><br/><br/>\
-<a href='http://codefor.de/stuttgart/' target='_blank' style='display:inline;background:none;color:black;'>&copy; Open Knowledge Lab Stuttgart a.o. (Code for Germany)</a>\
+<a href='https://codefor.de/stuttgart/' target='_blank' style='display:inline;background:none;color:black;'>&copy; Open Knowledge Lab Stuttgart a.o. (Code for Germany)</a>\
 </div></body></html>\r\n";
 
 const char WEB_ROOT_PAGE_CONTENT[] PROGMEM = "<a href='/values'>{t}</a><br/>\
-<a href='http://maps.luftdaten.info/' target='_blank'>{map}</a><br/>\
+<a href='https://maps.luftdaten.info/' target='_blank'>{map}</a><br/>\
 <a href='/config'>{conf}</a><br/>\
 <a href='/removeConfig'>{conf_delete}</a><br/>\
 <a href='/reset'>{restart}</a><br/>\


### PR DESCRIPTION
Code for stuttgart was forwarding to https anyways but
for maps.luftdaten.info was shown with an "unsecure" warning.