### PR TITLE
advertise a proper HTLM5 docttype to ensure standard mode

### DIFF
--- a/airrohr-firmware/html-content.h
+++ b/airrohr-firmware/html-content.h
@@ -34,7 +34,7 @@ const char SENSORS_BMP180[] PROGMEM = "BMP180";
 const char SENSORS_BMP280[] PROGMEM = "BMP280";
 const char SENSORS_BME280[] PROGMEM = "BME280";
 
-const char WEB_PAGE_HEADER[] PROGMEM = "<html>\
+const char WEB_PAGE_HEADER[] PROGMEM = "<!DOCTYPE html><html>\
 <head>\
 <title>{t}</title>\
 <meta name='viewport' content='width=device-width'>\


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode

Chrome web-dev tools complained that we are running in quirks mode.
