### PR TITLE
Adapt to a changed API of the dht sensor

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -2415,7 +2415,7 @@ static String sensorDHT() {
 		if (isnan(t) || isnan(h)) {
 			delay(100);
 			h = dht.readHumidity();
-			t = dht.readTemperature(false);
+			t = dht.readTemperature(false, true);
 		}
 		if (isnan(t) || isnan(h)) {
 			debug_out(String(FPSTR(SENSORS_DHT22)) + FPSTR(DBG_TXT_COULDNT_BE_READ), DEBUG_ERROR, 1);


### PR DESCRIPTION
False now means Celsius...
We need to call readTemperature(false, true) to force a read.

Do _NOT_ merge it. This PR is mostly reminder. This needs more testing before merge.