### PR TITLE
Require username AND password to be set

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1094,11 +1094,11 @@ void writeConfig() {
  *****************************************************************/
 void create_basic_auth_strings() {
 	basic_auth_custom = "";
-	if (cfg::user_custom[0] != '\0' || cfg::pwd_custom[0] != '\0') {
+	if (cfg::user_custom[0] != '\0' && cfg::pwd_custom[0] != '\0') {
 		basic_auth_custom = base64::encode(String(cfg::user_custom) + ":" + String(cfg::pwd_custom));
 	}
 	basic_auth_influx = "";
-	if (cfg::user_influx[0] != '\0' || cfg::pwd_influx[0] != '\0') {
+	if (cfg::user_influx[0] != '\0' && cfg::pwd_influx[0] != '\0') {
 		basic_auth_influx = base64::encode(String(cfg::user_influx) + ":" + String(cfg::pwd_influx));
 	}
 }


### PR DESCRIPTION
@ricki-z this is more a question or request for comment than a PR.

I would assume that both username and password need to be non-empty strings (not one OR the other). Do you know?