### PR TITLE
zDo not set the sample count to 0 at the end of each loop

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -4026,7 +4026,6 @@ void loop() {
 		last_data_string = data;
 		lowpulseoccupancyP1 = 0;
 		lowpulseoccupancyP2 = 0;
-		sample_count = 0;
 		last_micro = 0;
 		min_micro = 1000000000;
 		max_micro = 0;


### PR DESCRIPTION
We want to count the samples, reset sample_count to 0 at the end of each loop doesn't help.