### PR TITLE
Wait on reading response from server (Fixes #327)

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -2193,7 +2193,13 @@ void sendData(const String& data, const int pin, const char* host, const int htt
 
 		client->println(data);
 
-		delay(10);
+		// wait for response
+		int retries = 5;
+		while (client->connected() && !client->available()) {
+			delay(10);
+			if (!--retries)
+				break;
+		}
 
 		// Read reply from server and print them
 		while(client->available()) {


### PR DESCRIPTION
Give the server some time to get back to us with a reply, otherwise
in case of proxied connections via nginx, the proxy can fail
the request when the client disconnects too quickly. Also we might
not actually see the reply.