### PR TITLE
Set the platformio programming upload speed to 921600 bps

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -44,6 +44,7 @@ lib_deps_external =
   Wire
   LiquidCrystal_I2C@1.1.2
 extra_scripts = platformio_script.py
+upload_speed = 921600
 
 [env:nodemcuv2]
 lang = DE
@@ -54,6 +55,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_DE'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_bg]
 lang = bg
@@ -64,6 +66,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_BG'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_cz]
 lang = cz
@@ -74,6 +77,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_CZ'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_dk]
 lang = dk
@@ -84,6 +88,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_DK'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_en]
 lang = en
@@ -94,6 +99,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_EN'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_es]
 lang = es
@@ -104,6 +110,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_ES'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_fr]
 lang = fr
@@ -114,6 +121,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_FR'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_it]
 lang = it
@@ -124,6 +132,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_IT'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_lu]
 lang = lu
@@ -134,6 +143,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_LU'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_nl]
 lang = nl
@@ -144,6 +154,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_NL'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_pl]
 lang = pl
@@ -154,6 +165,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_PL'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_pt]
 lang = pt
@@ -164,6 +176,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_PT'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_ru]
 lang = ru
@@ -174,6 +187,7 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_RU'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 
 [env:nodemcuv2_se]
 lang = se
@@ -184,4 +198,5 @@ board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_SE'
 lib_deps = ${common.lib_deps_external}
 extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
 


### PR DESCRIPTION
This improves the programming time from about 1m4s to about 24s when building and uploading using platformio, saving a lot of time in the development process.

This is done by creating a variable upload_speed in the 'common' environment and referring to this variable in all of the other platformio environments for each language.