### PR TITLE
Encrypting default WiFi connection after setup

### DIFF
--- a/airrohr-firmware/Readme.md
+++ b/airrohr-firmware/Readme.md
@@ -23,7 +23,7 @@ ppd42ns-wificonfig-ppd-sds-dht.spiffs.bin	-	Binary mit leerem Dateisystem, zum L
 ## WLAN Konfiguration
 siehe auch Wiki-Seite auf Github [Konfiguration der Sensoren](https://github.com/opendata-stuttgart/meta/wiki/Konfiguration-der-Sensoren)
 
-Wenn das vorgegebene WLAN nach 20 Sekunden nicht erreichbar ist, wird ein Access-Point eingerichtet, der über "Feinstaubsensor-\[Sensor-ID\]" erreichbar ist. Nach dem Verbinden zu diesem Accesspoint sollten alle Anfragen auf die Konfigurationsseite umgeleitet werden. Direkte Adresse der Seite ist http://192.168.4.1/ .
+Wenn das vorgegebene WLAN nach 20 Sekunden nicht erreichbar ist, wird ein Access-Point eingerichtet, der über "ESP-\[Sensor-ID\]" erreichbar ist. Das Passwort ist "**ParticularMatter255**". Nach dem Verbinden zu diesem Accesspoint sollten alle Anfragen auf die Konfigurationsseite umgeleitet werden. Direkte Adresse der Seite ist http://192.168.4.1/ .
 
 Konfigurierbar sind:
 * WLAN-Name und Passwort

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -248,7 +248,7 @@ namespace cfg {
 	void initNonTrivials(const char* id) {
 		strcpy(cfg::current_lang, CURRENT_LANG);
 		if (fs_ssid[0] == '\0') {
-			strcpy(fs_ssid, "Feinstaubsensor-");
+			strcpy(fs_ssid, "ESP");
 			strcat(fs_ssid, id);
 		}
 	}

--- a/airrohr-firmware/ext_def.h
+++ b/airrohr-firmware/ext_def.h
@@ -12,7 +12,7 @@
 
 // Sensor Wifi config (config mode)
 #define FS_SSID ""
-#define FS_PWD ""
+#define FS_PWD "ParticulateMatter255"
 
 // Wohin gehen die Daten?
 #define SEND2DUSTI 1


### PR DESCRIPTION
As described in https://github.com/opendata-stuttgart/sensors-software/issues/383 there is a serious security issue when setting up the sensor for the first time.

The credentials of your home WiFi (or whatever WiFi you try to connect your sensor to) are transmitted in plain text so that a potential attacker can sniff them without any effort. Once inside your network the attacker could do a lot of harm to other devices on your network.

To overcome this problem, I introduced a default password "ParticulateMatter255" in `ext_def.h`.

Furthermore, I wanted to avoid that an attacker can easily find out this password by just reading the AP's SSID (when finding the default SSID "Feinstaubsensor-<chipid>" the attacker would only have to search this word on google to find the default password which would enable him/her to decrypt the credentials again...). Therefore I renamed the SSID to the more generic term ESP<chipid> which is used more widely and therefore wouldn't allow an attacker to directly deduct which password to use for decryption.

This is not a perfect solution but for ~90% of usecases this should be safe enough and in any case much safer than the actual solution of not having any encryption on the default access point.

Keep in mind that the manual(s) for setting up the sensor need to be adapted to these changes.