### PR TITLE
Set min time for sending time when SDS011 is in use. Fixes #426 

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1553,6 +1553,11 @@ void webserver_config() {
 #undef readTimeParam
 #undef readPasswdParam
 
+    // Check sending_intervall_ms. It must be larger than SDS011 time acquisition requirement if SDS011 is used
+    if ((sds_read) && (sending_intervall_ms < (WARMUPTIME_SDS_MS + READINGTIME_SDS_MS))) {
+      sending_intervall_ms = WARMUPTIME_SDS_MS + READINGTIME_SDS_MS;
+    }
+
 		page_content += line_from_value(tmpl(FPSTR(INTL_SEND_TO), F("Luftdaten.info")), String(send2dusti));
 		page_content += line_from_value(tmpl(FPSTR(INTL_SEND_TO), F("Madavi")), String(send2madavi));
 		page_content += line_from_value(tmpl(FPSTR(INTL_READ_FROM), "DHT"), String(dht_read));


### PR DESCRIPTION
If SDS011 is enabled, the sending interval must be greater or equal to SDS011 time acquisition requirement (20 seconds). This PR adds a check in webserver_config() function for the sending interval to force its value to be at least equal to the SDS011 time acquisition requirement before the configuration is written to the flash by the function writeConfig(). If the value is greater it is saved without changes.
