### PR TITLE
Add call to MDNS.update(), this is required for correct MDNS operation.

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -4287,4 +4287,6 @@ void loop() {
 	}
 	yield();
 //	if (sample_count % 500 == 0) { Serial.println(ESP.getFreeHeap(),DEC); }
+
+    MDNS.update();
 }


### PR DESCRIPTION
This adds a call to MDNS.update().

MDNS publishes the ip of the ESP8266 wifi device on the local network as xxxx.local.
MDNS.begin() is typically called in setup(). MDNS.update() is typically called in loop() to keep the MDNS subsystem alive. It might work without the update() call, but it should really be called at regular times.

See also the example code at the mDNS source code for ESP8266:
https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266mDNS/examples/mDNS_Web_Server/mDNS_Web_Server.ino#L76