### PR TITLE
Update Adafroit Bosch sensors to latest releases

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -23,11 +23,11 @@ board_build.f_cpu = 160000000L
 ; ESP8266WiFi in both cases is necessary to solve a case sensitivity issue with WiFiUdp.h
 ; TinyGPSPlus is not yet in platformio - https://github.com/platformio/platformio-libmirror/issues/99
 lib_deps_external =
-  Adafruit Unified Sensor@1.0.2
-  Adafruit BME280 Library@1.0.7
-  Adafruit BMP280 Library@1.0.2
-  Adafruit BMP085 Library@1.0.0
-  Adafruit HTU21DF Library@1.0.1
+  Adafruit Unified Sensor@1.0.3
+  Adafruit BME280 Library@1.0.9
+  Adafruit BMP280 Library@1.0.4
+  Adafruit BMP085 Library@1.0.1
+  Adafruit HTU21DF Library@1.0.2
   ArduinoJson@5.13.2
   DallasTemperature@3.8.0
   DNSServer


### PR DESCRIPTION
This includes several bugfixes, including BME280
sensor reporting incorrect pressure reading:

https://github.com/adafruit/Adafruit_BME280_Library/pull/39