### PR TITLE
Skip erratic readings from SDS011 sensor

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1325,13 +1325,6 @@ static String tmpl(const String& patt, const String& value) {
 	return s;
 }
 
-static String tmpl(const String& patt, const String& value1, const String& value2) {
-	String s = patt;
-	s.replace("{v1}", value1);
-	s.replace("{v2}", value2);
-	return s;
-}
-
 static String tmpl(const String& patt, const String& value1, const String& value2, const String& value3) {
 	String s = patt;
 	s.replace("{v1}", value1);

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -4302,11 +4302,9 @@ static unsigned long sendDataToOptionalApis(const String &data) {
 
 		String aircms_data = "L=" + login + "&t=" + String(ts, DEC) + "&airrohr=" + data;
 		String token_hash = sha1Hex(token);
-		String hash = hmac1(String(token_hash), aircms_data + token);
-		char char_full_url[100];
-		sprintf(char_full_url, "%s%s", URL_AIRCMS, hash.c_str());
+    String full_url = URL_AIRCMS + hmac1(String(token_hash), aircms_data + token);
 
-		sendData(aircms_data, 0, HOST_AIRCMS, PORT_AIRCMS, char_full_url, true, false, "", FPSTR(TXT_CONTENT_TYPE_TEXT_PLAIN));
+		sendData(aircms_data, 0, HOST_AIRCMS, PORT_AIRCMS, full_url.c_str(), true, false, "", FPSTR(TXT_CONTENT_TYPE_TEXT_PLAIN));
 		sum_send_time += millis() - start_send;
 	}
 

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -2872,7 +2872,8 @@ String sensorSDS() {
 			if (len > 2) { checksum_is += value; }
 			len++;
 			if (len == 10 && checksum_ok == 1 && (msSince(starttime) > (cfg::sending_intervall_ms - READINGTIME_SDS_MS))) {
-				if ((! isnan(pm10_serial)) && (! isnan(pm25_serial))) {
+				if (!isnan(pm10_serial) && pm10_serial >= 0 && pm10_serial < 1999
+				    && !isnan(pm25_serial) && pm25_serial >= 0 && pm25_serial < 999) {
 					sds_pm10_sum += pm10_serial;
 					sds_pm25_sum += pm25_serial;
 					if (sds_pm10_min > pm10_serial) {


### PR DESCRIPTION
When the sensor fan is failed, the readouts will be consistent
999 and 1999, which appears to be indicating some kind of error
encoding (unfortunately the datasheet is not mentioning this).
    
Skip those values as they pollute the sensor map with incorrect
data (which appears as huge spikes in pollution in maps)