### PR TITLE
fixed issue #446

### DIFF
--- a/airrohr-firmware/platformio_script.py
+++ b/airrohr-firmware/platformio_script.py
@@ -3,6 +3,14 @@ import os
 import shutil
 from base64 import b64decode
 
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+
+config = configparser.ConfigParser()
+config.read("platformio.ini")
+
 flags = " ".join(env['LINKFLAGS'])
 flags = flags.replace("-u _printf_float", "")
 flags = flags.replace("-u _scanf_float", "")
@@ -14,7 +22,11 @@ env.Replace(
 def after_build(source, target, env):
   if not os.path.exists("./builds"):
     os.mkdir("./builds")
-  target_name = b64decode(ARGUMENTS.get("LANG"))
+
+  configName = b64decode(ARGUMENTS.get("PIOENV"))
+  sectionName = 'env:' + configName
+  lang = config.get(sectionName, "lang")
+  target_name = lang
   shutil.copy(target[0].path, "./builds/latest_"+target_name.lower()+".bin")
 
 env.AddPostAction("$BUILD_DIR/firmware.bin", after_build)


### PR DESCRIPTION
read "LANG" setting from platformio.ini via configparser instead of ARGUMENTS.get("LANG") because ARGUMENTS.get("LANG") is not defined in my recent installation.
