### PR TITLE
ESP32 Board target compilation fixes

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -2,6 +2,7 @@ NRZ-2019-124-B6
 * noise sensor added
 * Sensirion SPS30 added
 * option to flip OLED output
+* Fix crash on selecting available networks in AP mode
 
 NRZ-2019-124-B5
 * some comments removed

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1822,13 +1822,13 @@ void webserver_wifi() {
 		page_content += FPSTR(INTL_NO_NETWORKS);
 		page_content += FPSTR(BR_TAG);
 	} else {
-		std::unique_ptr<int[]> indices(new int[count_wifiInfo]);
+		std::unique_ptr<unsigned[]> indices(new unsigned[count_wifiInfo]);
 		debug_outln(F("output config page 2"), DEBUG_MIN_INFO);
-		for (int i = 0; i < count_wifiInfo; i++) {
+		for (unsigned i = 0; i < count_wifiInfo; ++i) {
 			indices[i] = i;
 		}
-		for (int i = 0; i < count_wifiInfo; i++) {
-			for (int j = i + 1; j < count_wifiInfo; j++) {
+		for (unsigned i = 0; i < count_wifiInfo; i++) {
+			for (unsigned j = i + 1; j < count_wifiInfo; j++) {
 				if (wifiInfo[indices[j]].RSSI > wifiInfo[indices[i]].RSSI) {
 					std::swap(indices[i], indices[j]);
 				}

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1841,7 +1841,7 @@ void webserver_wifi() {
 				continue;
 			}
 			for (int j = i + 1; j < count_wifiInfo; j++) {
-				if (strncmp(wifiInfo[indices[i]].ssid, wifiInfo[indices[j]].ssid, 35) == 0) {
+				if (strncmp(wifiInfo[indices[i]].ssid, wifiInfo[indices[j]].ssid, sizeof(wifiInfo[0].ssid)) == 0) {
 					indices[j] = -1; // set dup aps to index -1
 					++duplicateSsids;
 				}
@@ -2251,7 +2251,7 @@ void wifiConfig() {
 #if defined(ESP8266)
 			WiFi.getNetworkInfo(i, SSID, wifiInfo[i].encryptionType, wifiInfo[i].RSSI, BSSID, wifiInfo[i].channel, wifiInfo[i].isHidden);
 #endif
-			SSID.toCharArray(wifiInfo[i].ssid, 35);
+			SSID.toCharArray(wifiInfo[i].ssid, sizeof(wifiInfo[0].ssid));
 		}
 
 		WiFi.mode(WIFI_AP);

--- a/airrohr-firmware/dnms_i2c.cpp
+++ b/airrohr-firmware/dnms_i2c.cpp
@@ -173,14 +173,14 @@ uint16_t dnms_fill_cmd_send_buf(uint8_t *buf, uint16_t cmd, const uint16_t *args
   uint8_t i;
   uint16_t idx = 0;
 
-  buf[idx++] = (u8)((cmd & 0xFF00) >> 8);
-  buf[idx++] = (u8)((cmd & 0x00FF) >> 0);
+  buf[idx++] = (uint8_t)((cmd & 0xFF00) >> 8);
+  buf[idx++] = (uint8_t)((cmd & 0x00FF) >> 0);
 
   for (i = 0; i < num_args; ++i) {
-    buf[idx++] = (u8)((args[i] & 0xFF00) >> 8);
-    buf[idx++] = (u8)((args[i] & 0x00FF) >> 0);
+    buf[idx++] = (uint8_t)((args[i] & 0xFF00) >> 8);
+    buf[idx++] = (uint8_t)((args[i] & 0x00FF) >> 0);
 
-    crc = dnms_common_generate_crc((u8 *)&buf[idx - 2], DNMS_WORD_SIZE);
+    crc = dnms_common_generate_crc((uint8_t *)&buf[idx - 2], DNMS_WORD_SIZE);
     buf[idx++] = crc;
   }
   return idx;

--- a/airrohr-firmware/dnms_i2c.h
+++ b/airrohr-firmware/dnms_i2c.h
@@ -57,19 +57,19 @@
 #define DNMS_CMD_READ_LEQ               0x0005
 
 
-#define be16_to_cpu(s) (((u16)(s) << 8) | (0xff & ((u16)(s)) >> 8))
-#define be32_to_cpu(s) (((u32)be16_to_cpu(s) << 16) | \
+#define be16_to_cpu(s) (((uint16_t)(s) << 8) | (0xff & ((uint16_t)(s)) >> 8))
+#define be32_to_cpu(s) (((uint32_t)be16_to_cpu(s) << 16) | \
                         (0xffff & (be16_to_cpu((s) >> 16))))
-#define be64_to_cpu(s) (((u64)be32_to_cpu(s) << 32) | \
-                        (0xffffffff & ((u64)be32_to_cpu((s) >> 32))))
+#define be64_to_cpu(s) (((uint64_t)be32_to_cpu(s) << 32) | \
+                        (0xffffffff & ((uint64_t)be32_to_cpu((s) >> 32))))
 /**
    Convert a word-array to a bytes-array, effectively reverting the
    host-endianness to big-endian
-   @a:  word array to change (must be (u16 *) castable)
+   @a:  word array to change (must be (uint16_t *) castable)
    @w:  number of word-sized elements in the array (DNMS_NUM_WORDS(a)).
 */
 #define DNMS_WORDS_TO_BYTES(a, w) \
-  for (u16 *__a = (u16 *)(a), __e = (w), __w = 0; __w < __e; ++__w) { \
+  for (uint16_t *__a = (uint16_t *)(a), __e = (w), __w = 0; __w < __e; ++__w) { \
     __a[__w] = be16_to_cpu(__a[__w]); \
   }
 
@@ -119,7 +119,7 @@ int16_t dnms_read_leq(struct dnms_measurements *leq);
 
 int16_t dnms_i2c_read_cmd(uint8_t address, uint16_t cmd, uint16_t *data_words, uint16_t num_words);
 
-//int16_t dnms_i2c_delayed_read_cmd(uint8_t address, uint16_t cmd, uint32_t delay_us, uint16_t *data_words, u16 num_words);
+//int16_t dnms_i2c_delayed_read_cmd(uint8_t address, uint16_t cmd, uint32_t delay_us, uint16_t *data_words, uint16_t num_words);
 
 int8_t dnms_i2c_read(uint8_t address, uint8_t* data, uint16_t count);
 

--- a/airrohr-firmware/sps30_i2c.cpp
+++ b/airrohr-firmware/sps30_i2c.cpp
@@ -175,7 +175,8 @@ int16_t sps30_get_fan_auto_cleaning_interval(uint32_t *interval_seconds) {
 
 int16_t sps30_set_fan_auto_cleaning_interval(uint32_t interval_seconds) {
   int16_t ret;
-  const uint16_t data[] = {(interval_seconds & 0xFFFF0000) >> 16, (interval_seconds & 0x0000FFFF) >> 0};
+  const uint16_t data[] = {(uint16_t)((interval_seconds & 0xFFFF0000) >> 16),
+                           (uint16_t)((interval_seconds & 0x0000FFFF) >> 0)};
 
   ret = sensirion_i2c_write_cmd_with_args(SPS_I2C_ADDRESS,  SPS_CMD_AUTOCLEAN_INTERVAL, data, SENSIRION_NUM_WORDS(data));
 //  sensirion_sleep_usec(SPS_WRITE_DELAY_US);
@@ -199,7 +200,7 @@ int16_t sps30_get_fan_auto_cleaning_interval_days(uint8_t *interval_days) {
 
 
 int16_t sps30_set_fan_auto_cleaning_interval_days(uint8_t interval_days) {
-  return sps30_set_fan_auto_cleaning_interval((u32)interval_days * 24 * 60 * 60);
+  return sps30_set_fan_auto_cleaning_interval((uint32_t)interval_days * 24 * 60 * 60);
 }
 */
 
@@ -271,7 +272,7 @@ int8_t sensirion_i2c_write(uint8_t address, const uint8_t* data, uint16_t count)
    @param useconds the sleep time in microseconds
 */
 /*
-void sensirion_sleep_usec(u32 useconds) {
+void sensirion_sleep_usec(uint32_t useconds) {
   delay((useconds / 1000) + 1);
 }
 */
@@ -307,14 +308,14 @@ uint16_t sensirion_fill_cmd_send_buf(uint8_t *buf, uint16_t cmd, const uint16_t 
   uint8_t i;
   uint16_t idx = 0;
 
-  buf[idx++] = (u8)((cmd & 0xFF00) >> 8);
-  buf[idx++] = (u8)((cmd & 0x00FF) >> 0);
+  buf[idx++] = (uint8_t)((cmd & 0xFF00) >> 8);
+  buf[idx++] = (uint8_t)((cmd & 0x00FF) >> 0);
 
   for (i = 0; i < num_args; ++i) {
-    buf[idx++] = (u8)((args[i] & 0xFF00) >> 8);
-    buf[idx++] = (u8)((args[i] & 0x00FF) >> 0);
+    buf[idx++] = (uint8_t)((args[i] & 0xFF00) >> 8);
+    buf[idx++] = (uint8_t)((args[i] & 0x00FF) >> 0);
 
-    crc = sensirion_common_generate_crc((u8 *)&buf[idx - 2],
+    crc = sensirion_common_generate_crc((uint8_t *)&buf[idx - 2],
                                         SENSIRION_WORD_SIZE);
     buf[idx++] = crc;
   }
@@ -326,7 +327,7 @@ int16_t sensirion_i2c_read_bytes(uint8_t address, uint8_t *data, uint16_t num_wo
   uint16_t i, j;
   uint16_t size = num_words * (SENSIRION_WORD_SIZE + CRC8_LEN);
   uint16_t word_buf[SENSIRION_MAX_BUFFER_WORDS];
-  uint8_t * const buf8 = (u8 *)word_buf;
+  uint8_t * const buf8 = (uint8_t *)word_buf;
 
   ret = sensirion_i2c_read(address, buf8, size);
   if (ret != STATUS_OK) {

--- a/airrohr-firmware/sps30_i2c.h
+++ b/airrohr-firmware/sps30_i2c.h
@@ -74,18 +74,18 @@
 #define SPS_WRITE_DELAY_US              20000
 
 
-#define be16_to_cpu(s) (((u16)(s) << 8) | (0xff & ((u16)(s)) >> 8))
-#define be32_to_cpu(s) (((u32)be16_to_cpu(s) << 16) | \
+#define be16_to_cpu(s) (((uint16_t)(s) << 8) | (0xff & ((uint16_t)(s)) >> 8))
+#define be32_to_cpu(s) (((uint32_t)be16_to_cpu(s) << 16) | \
                         (0xffff & (be16_to_cpu((s) >> 16))))
 
 /**
    Convert a word-array to a bytes-array, effectively reverting the
    host-endianness to big-endian
-   @a:  word array to change (must be (u16 *) castable)
+   @a:  word array to change (must be (uint16_t *) castable)
    @w:  number of word-sized elements in the array (SENSIRION_NUM_WORDS(a)).
 */
 #define SENSIRION_WORDS_TO_BYTES(a, w) \
-  for (u16 *__a = (u16 *)(a), __e = (w), __w = 0; __w < __e; ++__w) { \
+  for (uint16_t *__a = (uint16_t *)(a), __e = (w), __w = 0; __w < __e; ++__w) { \
     __a[__w] = be16_to_cpu(__a[__w]); \
   }
 
@@ -155,7 +155,7 @@ int16_t sps30_set_fan_auto_cleaning_interval_days(uint8_t interval_days);
 int16_t sensirion_i2c_read_cmd(uint8_t address, uint16_t cmd, uint16_t *data_words, uint16_t num_words);
 
 /*
-int16_t sensirion_i2c_delayed_read_cmd(uint8_t address, uint16_t cmd, uint32_t delay_us, uint16_t *data_words, u16 num_words);
+int16_t sensirion_i2c_delayed_read_cmd(uint8_t address, uint16_t cmd, uint32_t delay_us, uint16_t *data_words, uint16_t num_words);
 */
 
 int8_t sensirion_i2c_read(uint8_t address, uint8_t* data, uint16_t count);


### PR DESCRIPTION
The includes for ESP8266 need to be repeated in the ESP32 section.
Also the typedefs u8/u16/u32/u64 are not existing on this platform.
Replace with corresponding standard types uint8_t/uint16_t/uint32_t/uint64_t.