### PR TITLE
Tie to the older PlatformIO version to use Arduino Core 2.4.2

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -44,10 +44,15 @@ lib_deps_external =
   LiquidCrystal_I2C@1.1.2
   ESPSoftwareSerial@3.4.1
 extra_scripts = platformio_script.py
+# This release is reflecting the Arduino Core 2.4.2 release
+# When the requirement for Arduino Core is raised, this
+# needs to be adjusted to the matching version from
+# https://github.com/platformio/platform-espressif8266/releases
+platform_version = espressif8266@1.8.0
 
 [env:nodemcuv2]
 lang = DE
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -57,7 +62,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_bg]
 lang = bg
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -67,8 +72,8 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_cz]
 lang = cz
-platform = espressif8266
 framework = arduino
+platform = ${common.platform_version}
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
 build_flags = ${common.build_flags} '-DINTL_CZ'
@@ -77,7 +82,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_dk]
 lang = dk
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -87,7 +92,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_en]
 lang = en
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -97,7 +102,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_es]
 lang = es
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -107,7 +112,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_fr]
 lang = fr
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -117,7 +122,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_it]
 lang = it
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -127,7 +132,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_lu]
 lang = lu
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -137,7 +142,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_nl]
 lang = nl
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -147,7 +152,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_pl]
 lang = pl
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -157,7 +162,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_pt]
 lang = pt
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -167,7 +172,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_ru]
 lang = ru
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
@@ -177,7 +182,7 @@ extra_scripts = ${common.extra_scripts}
 
 [env:nodemcuv2_se]
 lang = se
-platform = espressif8266
+platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}


### PR DESCRIPTION
This makes the platformio / travis build more resemble the
actual build. As found out in recent merges, there were API
differences being introduced and not caught because the
testing was done against a too new Core version.

This also reduces flash size of the platformio build from
549376 to 510000.