### PR TITLE
Two Stage OTA update from SPIFFS

### DIFF
--- a/airrohr-update-loader/airrohr-update-loader.ino
+++ b/airrohr-update-loader/airrohr-update-loader.ino
@@ -1,5 +1,3 @@
-#include <Arduino.h>
-
 /************************************************************************
  *                                                                      *
  *  This source code needs to be compiled for the board                 *
@@ -31,7 +29,6 @@
  *                                                                      *
  ************************************************************************
  *                                                                      *
- *
  * 06.07.2018
  * Der Sketch verwendet 459607 Bytes (44%) des Programmspeicherplatzes. Das Maximum sind 1044464 Bytes.
  * Globale Variablen verwenden 48736 Bytes (59%) des dynamischen Speichers, 33184 Bytes für lokale Variablen verbleiben. Das Maximum sind 81920 Bytes.
@@ -43,20 +40,19 @@
  * Der Sketch verwendet 489152 Bytes (46%) des Programmspeicherplatzes. Das Maximum sind 1044464 Bytes.
  * Globale Variablen verwenden 37160 Bytes (45%) des dynamischen Speichers, 44760 Bytes für lokale Variablen verbleiben. Das Maximum sind 81920 Bytes.
  *
+ * 06.09.2019: Using SPIFFS for update
+ * DATA:    [===       ]  32.9% (used 26960 bytes from 81920 bytes)
+ * PROGRAM: [===       ]  26.2% (used 273848 bytes from 1044464 bytes)
  ************************************************************************/
 // increment on change
-#define SOFTWARE_VERSION "LOADER-001"
+#define SOFTWARE_VERSION "LOADER-002"
 
 /*****************************************************************
  * Includes                                                      *
  *****************************************************************/
+#include <Arduino.h>
 #include <FS.h>                     // must be first
-#include <ESP8266WiFi.h>
-#include <ESP8266httpUpdate.h>
-#include <ArduinoJson.h>
-#include <time.h>
-#include <coredecls.h>
-#include <assert.h>
+#include <StreamString.h>
 
 // define debug levels
 #define DEBUG_ERROR 1
@@ -75,227 +71,96 @@
  * as they are part of the json format used to persist the data.  *
  ******************************************************************/
 namespace cfg {
-	char wlanssid[35];
-	char wlanpwd[65];
-
-	char current_lang[3] = "DE";
-	char www_username[65];
-	char www_password[65];
-	bool www_basicauth_enabled;
-
-	char fs_ssid[33];
-	char fs_pwd[65];
-
-	char version_from_local_config[20] = "";
-
-	bool auto_update;
-	bool use_beta;
-
-	int  debug;
-
-	unsigned long time_for_wifi_config = 600000;
-	unsigned long sending_intervall_ms = 145000;
-
-	void initNonTrivials(const char* id) {
-		strcpy(cfg::current_lang, "DE");
-		if (fs_ssid[0] == '\0') {
-			strcpy(fs_ssid, "Feinstaubsensor-");
-			strcat(fs_ssid, id);
-		}
-	}
+	int debug = DEBUG_MIN_INFO;
 }
-
-#define UPDATE_HOST "www.madavi.de"
-#define UPDATE_URL "/sensor/update/firmware.php"
-#define UPDATE_PORT 80
-
-#define JSON_BUFFER_SIZE 2000
-
-int TimeZone = 1;
-
-String esp_chipid;
-
-bool sntp_time_is_set = false;
-
-bool got_ntp = false;
 
 /*****************************************************************
  * Debug output                                                  *
  *****************************************************************/
 
+#define debug_level_check(level) if(level > cfg::debug) return;
 
-#define debug_level_check if(level > cfg::debug) return;
+static void debug_outln_info(const __FlashStringHelper* text) {
+	debug_level_check(DEBUG_MIN_INFO); Serial.println(text);
+}
 
-void debug_out(const String& text, const int level) { debug_level_check; Serial.print(text); }
-void debug_out_bool(const bool text, const int level) { debug_level_check; Serial.print(String(text)); }
-void debug_out(const __FlashStringHelper* text, const int level) { debug_level_check; Serial.print(text); }
+static void debug_outln_info(const __FlashStringHelper* text, const String& option) {
+        debug_level_check(DEBUG_MIN_INFO);
+        Serial.print(text);
+        Serial.println(option);
+}
 
-void debug_outln(const String& text, const int level) { debug_level_check; Serial.println(text); }
-void debug_outln_bool(const bool text, const int level) { debug_level_check; Serial.println(String(text)); }
-void debug_outln(const __FlashStringHelper* text, const int level) { debug_level_check; Serial.println(text); }
+static void debug_outln_error(const __FlashStringHelper* text) {
+        debug_level_check(DEBUG_ERROR); Serial.println(text);
+}
 
 #undef debug_level_check
 
-/*****************************************************************
- * read config from spiffs                                       *
- *****************************************************************/
-void readConfig() {
-	using namespace cfg;
-	String json_string = "";
-	debug_outln(F("mounting FS..."), DEBUG_MIN_INFO);
+bool use_old_firmware = false;
 
-	if (SPIFFS.begin()) {
-		debug_outln(F("mounted file system..."), DEBUG_MIN_INFO);
-		if (SPIFFS.exists("/config.json")) {
-			//file exists, reading and loading
-			debug_outln(F("reading config file..."), DEBUG_MIN_INFO);
-			File configFile = SPIFFS.open("/config.json", "r");
-			if (configFile) {
-				debug_outln(F("opened config file..."), DEBUG_MIN_INFO);
-				const size_t size = configFile.size();
-				// Allocate a buffer to store contents of the file.
-				std::unique_ptr<char[]> buf(new char[size]);
+static bool SPIFFSAutoUpdate() {
+	const char firmware_filename[] = "/firmware.bin";
+	const char firmware_md5_filename[] = "/firmware.bin.md5";
+	const char prev_firmware_filename[] = "/firmware.old";
 
-				configFile.readBytes(buf.get(), size);
-				DynamicJsonDocument json(JSON_BUFFER_SIZE);
-				DeserializationError err = deserializeJson(json, configFile);
-				if (!err) {
-					debug_outln(F("parsed json..."), DEBUG_MIN_INFO);
-					if (json.containsKey("SOFTWARE_VERSION")) {
-						strcpy(version_from_local_config, json["SOFTWARE_VERSION"]);
-					}
+	String firmware = use_old_firmware ? prev_firmware_filename : firmware_filename;
 
-#define setFromJSON(key)    if (json.containsKey(#key)) key = json[#key];
-#define strcpyFromJSON(key) if (json.containsKey(#key)) strcpy(key, json[#key]);
-					strcpyFromJSON(current_lang);
-					strcpyFromJSON(wlanssid);
-					strcpyFromJSON(wlanpwd);
+	if (!SPIFFS.exists(firmware)) {
+		debug_outln_info(F("No Firmware file found, looking for: "), firmware);
+		return false;
+	}
+	File updateFile = SPIFFS.open(firmware, "r");
+	if (!updateFile) {
+		debug_outln_info(F("Failed to open : "), firmware);
+		return false;
+	}
+	if (updateFile.size() >= ESP.getFreeSketchSpace()) {
+		debug_outln_error(F("Cannot update, Firmware too large"));
+		return false;
+	}
+	if (!Update.begin(updateFile.size(), U_FLASH)) {
+		StreamString error;
+		Update.printError(error);
 
-					setFromJSON(auto_update);
-					setFromJSON(use_beta);
-					setFromJSON(debug);
-					configFile.close();
-#undef setFromJSON
-#undef strcpyFromJSON
-				} else {
-					debug_outln(F("failed to load json config"), DEBUG_ERROR);
-				}
-			} else {
-				debug_outln(F("config file not found ..."), DEBUG_ERROR);
-			}
-		} else {
-			debug_outln(F("failed to mount FS"), DEBUG_ERROR);
+		debug_outln_info(F("Update.begin returned: "), error);
+		return false;
+	}
+	if (!use_old_firmware) {
+		File md5File = SPIFFS.open(firmware_md5_filename, "r");
+		if (md5File) {
+			String md5sum_firmware = md5File.readString();
+			debug_outln_info(F("Found firmware MD5: "), md5sum_firmware);
+			Update.setMD5(md5sum_firmware.c_str());
+			md5File.close();
 		}
 	}
-}
+	if(Update.writeStream(updateFile) != updateFile.size()) {
+		StreamString error;
+		Update.printError(error);
 
-static void waitForWifiToConnect(int maxRetries) {
-	int retryCount = 0;
-	while ((WiFi.status() != WL_CONNECTED) && (retryCount <  maxRetries)) {
-		delay(500);
-		debug_out(".", DEBUG_MIN_INFO);
-		++retryCount;
+		debug_outln_info(F("Update.writeStream returned: "), error);
+		return false;
 	}
-}
+	updateFile.close();
 
-/*****************************************************************
- * WiFi auto connecting script                                   *
- *****************************************************************/
-void connectWifi() {
-	debug_outln(String(WiFi.status()), DEBUG_MIN_INFO);
-	WiFi.disconnect();
-	WiFi.setOutputPower(20.5);
-	WiFi.setPhyMode(WIFI_PHY_MODE_11N);
-	WiFi.mode(WIFI_STA);
-	WiFi.begin(cfg::wlanssid, cfg::wlanpwd); // Start WiFI
+	if (!Update.end()) {
+		StreamString error;
+		Update.printError(error);
 
-	debug_out(F("Connecting to "), DEBUG_MIN_INFO);
-	debug_outln(cfg::wlanssid, DEBUG_MIN_INFO);
-
-	waitForWifiToConnect(40);
-	debug_outln("", DEBUG_MIN_INFO);
-	debug_out(F("WiFi connected\nIP address: "), DEBUG_MIN_INFO);
-	debug_outln(WiFi.localIP().toString(), DEBUG_MIN_INFO);
-}
-
-/*****************************************************************
- * AutoUpdate                                                    *
- *****************************************************************/
-static void autoUpdate() {
-	if (!cfg::auto_update) return;
-
-	debug_outln(F("Starting OTA update ..."), DEBUG_MIN_INFO);
-	debug_out(F("NodeMCU firmware : "), DEBUG_MIN_INFO);
-	debug_outln(SOFTWARE_VERSION, DEBUG_MIN_INFO);
-	debug_outln(UPDATE_HOST, DEBUG_MED_INFO);
-	debug_outln(UPDATE_URL, DEBUG_MED_INFO);
-
-	String version = SOFTWARE_VERSION + String(" ") + esp_chipid + String(" ") + String("update_loader") + String(" ") +
-					 String(cfg::current_lang) + String(" ") + String(cfg::current_lang) + String(" ") +
-					 String(cfg::use_beta ? "BETA" : "");
-
-
-	WiFiClient client;
-
-#if defined(ESP8266)
-	const HTTPUpdateResult ret = ESPhttpUpdate.update(client, UPDATE_HOST, UPDATE_PORT, UPDATE_URL, version);
-	String LastErrorString = ESPhttpUpdate.getLastErrorString().c_str();
-#endif
-#if defined(ESP32)
-	t_httpUpdate_return ret = httpUpdate.update(client, UPDATE_HOST, UPDATE_PORT, UPDATE_URL, version);
-	String LastErrorString = httpUpdate.getLastErrorString().c_str();
-#endif
-
-	switch(ret) {
-	case HTTP_UPDATE_FAILED:
-		debug_out(F("Update failed ..."), DEBUG_ERROR);
-		debug_outln(LastErrorString, DEBUG_ERROR);
-		break;
-	case HTTP_UPDATE_NO_UPDATES:
-		debug_outln(F("No update found ..."), DEBUG_MIN_INFO);
-		break;
-	case HTTP_UPDATE_OK:
-		debug_outln(F("Update ok..."), DEBUG_MIN_INFO); // may not called we reboot the ESP
-		break;
+		debug_outln_info(F("Update.end() returned: "), error);
+		return false;
 	}
-}
 
-void time_is_set (void) {
-	sntp_time_is_set = true;
-}
+	debug_outln_info(F("Moving Firmware image to old."));
 
-static bool acquireNetworkTime() {
-	int retryCount = 0;
-	debug_outln(F("Setting time using SNTP"), DEBUG_MIN_INFO);
-	time_t now = time(nullptr);
-	debug_outln(String(ctime(&now)), DEBUG_MIN_INFO);
-	debug_outln(F("NTP.org:"), DEBUG_MIN_INFO);
-	settimeofday_cb(time_is_set);
-	configTime(8 * 3600, 0, "pool.ntp.org");
-	while (retryCount++ < 20) {
-		// later than 2000/01/01:00:00:00
-		if (sntp_time_is_set) {
-			now = time(nullptr);
-			debug_outln(ctime(&now), DEBUG_MIN_INFO);
-			return true;
-		}
-		delay(500);
-		debug_out(".", DEBUG_MIN_INFO);
-	}
-	debug_outln(F("\nrouter/gateway:"), DEBUG_MIN_INFO);
-	retryCount = 0;
-	configTime(0, 0, WiFi.gatewayIP().toString().c_str());
-	while (retryCount++ < 20) {
-		// later than 2000/01/01:00:00:00
-		if (sntp_time_is_set) {
-			now = time(nullptr);
-			debug_outln(ctime(&now), DEBUG_MIN_INFO);
-			return true;
-		}
-		delay(500);
-		debug_out(".", DEBUG_MIN_INFO);
-	}
-	return false;
+	SPIFFS.remove(prev_firmware_filename);
+	SPIFFS.remove(firmware_md5_filename);
+	SPIFFS.rename(firmware_filename, prev_firmware_filename);
+	SPIFFS.end();
+	debug_outln_info(F("Finished successfully.. Rebooting!"));
+	delay(500);
+	ESP.restart();
+	return true;
 }
 
 /*****************************************************************
@@ -303,22 +168,38 @@ static bool acquireNetworkTime() {
  *****************************************************************/
 void setup() {
 	Serial.begin(9600);					// Output to Serial at 9600 baud
+	pinMode(LED_BUILTIN, OUTPUT);
 
-	esp_chipid = String(ESP.getChipId());
-	cfg::initNonTrivials(esp_chipid.c_str());
-	readConfig();
-
-	connectWifi();
-	got_ntp = acquireNetworkTime();
-	debug_out(F("\nNTP time "), DEBUG_MIN_INFO);
-	debug_outln(String(got_ntp ? "" : "not ") + F("received"), DEBUG_MIN_INFO);
-	autoUpdate();
+	if (!SPIFFS.begin()) {
+		debug_outln_error(F("Failed to mount SPIFFS!"));
+		return;
+	}
 }
 
 /*****************************************************************
  * And action                                                    *
  *****************************************************************/
 void loop() {
-	yield();
-//	if (sample_count % 500 == 0) { Serial.println(ESP.getFreeHeap(),DEC); }
+
+	if (!SPIFFSAutoUpdate()) {
+		bool slow = false;
+
+		debug_outln_error(F("Update Failed."));
+		debug_outln_error(F("Please upload the latest firmware as '/firmware.bin' on SPIFSS to recover."));
+
+		for (int j = 0; j < 3; ++j) {
+			for(int i = 0; i < 3; ++i) {
+				digitalWrite(LED_BUILTIN, HIGH);
+				delay(60);
+				digitalWrite(LED_BUILTIN, LOW);
+				delay(slow ? 1000 : 400);
+				yield();
+			}
+			digitalWrite(LED_BUILTIN, HIGH);
+			delay(800);
+			slow = !slow;
+		}
+	}
+
+	use_old_firmware = !use_old_firmware;
 }

--- a/airrohr-update-loader/platformio.ini
+++ b/airrohr-update-loader/platformio.ini
@@ -22,14 +22,12 @@ board_build.f_cpu = 160000000L
 ; Always depend on specific library versions (wherever possible)
 ; Keep Library names in alphabetical order
 lib_deps_external =
-  ArduinoJson@6.11.5
-  ESP8266WiFi
-  ESP8266httpUpdate
 extra_scripts = platformio_script.py
-# This release is reflecting the Arduino Core 2.5.2 release
-# This needs to be adjusted to the matching version from
+# This release is reflecting the Arduino Core 2.4.2 release
+# When the requirement for Arduino Core is raised, this
+# needs to be adjusted to the matching version from
 # https://github.com/platformio/platform-espressif8266/releases
-platform_version = espressif8266@2.2.3
+platform_version = espressif8266@1.8.0
 
 [env:nodemcuv2]
 lang = DE


### PR DESCRIPTION
This loader variant looks for a file called firmware.bin
on the SPIFFS and triggers a Sketch Update precedure with it.
By uploading it to the OTA flash area and configuring eboot
to copy on boot, we're in-place replacing the updater-firmware
with the final firmware.

This produces a relatively small sketch of 271kb. the main airrohr-firmware
would have to download the new firmware version, save it on SPIFFS
 and then install the airror-update-loader via OTA. This one will
then do a local Update of the firmware from SPIFFS and rename it to
an old binary.