### PR TITLE
Further reduce temporary string creation

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -2219,6 +2219,8 @@ static void webserver_prometheus_endpoint() {
  * Webserver Images                                              *
  *****************************************************************/
 static void webserver_images() {
+	server.sendHeader(F("Cache-Control"), F("max-age=2592000, public"));
+
 	if (server.arg("name") == F("luftdaten_logo")) {
 		debug_outln_info(F("output luftdaten.info logo..."));
 		server.send_P(200, TXT_CONTENT_TYPE_IMAGE_SVG, LUFTDATEN_INFO_LOGO_SVG);


### PR DESCRIPTION
The pattern

  page_content += foo()

is suboptimal, as that constructs a temporary String() as return
value which is then inlining the ~String() for this temporary string,
adding code bloat. we can replace that with

  add_foo(page_content, ..)

which is less overhead. Saves about 7kb of code size.