### PR TITLE
Advertise in AP mode the sensor via final MDNS name

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -132,7 +132,6 @@
 #if defined(ESP8266)
 #include <FS.h>                     // must be first
 #include <ESP8266WiFi.h>
-#include <DNSServer.h>
 #include <ESP8266WebServer.h>
 #include <ESP8266mDNS.h>
 #include <ESP8266httpUpdate.h>
@@ -154,7 +153,6 @@
 #include <hwcrypto/sha.h>
 #include <HTTPUpdate.h>
 #include <WebServer.h>
-#include <DNSServer.h>
 #include <ESPmDNS.h>
 #endif
 
@@ -165,6 +163,7 @@
 #include <SH1106.h>
 #include <LiquidCrystal_I2C.h>
 #include <ArduinoJson.h>
+#include <DNSServer.h>
 #include "./DHT.h"
 #include <Adafruit_HTU21DF.h>
 #include <Adafruit_BMP085.h>
@@ -174,7 +173,6 @@
 #include <TinyGPS++.h>
 #include "./sps30_i2c.h"
 #include "./dnms_i2c.h"
-
 
 #if defined(INTL_BG)
 #include "intl_bg.h"
@@ -951,6 +949,7 @@ static void disable_unneeded_nmea() {
 /*****************************************************************
  * read config from spiffs                                       *
  *****************************************************************/
+
 static void readConfig() {
 	using namespace cfg;
 	String json_string;
@@ -2301,65 +2300,56 @@ static void wifiConfig() {
 	WiFi.disconnect(true);
 	debug_outln_info(F("scan for wifi networks..."));
 	count_wifiInfo = WiFi.scanNetworks(false /* scan async */, true /* show hidden networks */);
-	{
-		delete [] wifiInfo;
-		wifiInfo = new struct_wifiInfo[count_wifiInfo];
+	delete [] wifiInfo;
+	wifiInfo = new struct_wifiInfo[count_wifiInfo];
 
-		for (int i = 0; i < count_wifiInfo; i++) {
-			String SSID;
-			uint8_t* BSSID;
+	for (int i = 0; i < count_wifiInfo; i++) {
+		String SSID;
+		uint8_t* BSSID;
 
-			memset(&wifiInfo[i], 0, sizeof(struct_wifiInfo));
+		memset(&wifiInfo[i], 0, sizeof(struct_wifiInfo));
 #if defined(ESP8266)
-			WiFi.getNetworkInfo(i, SSID, wifiInfo[i].encryptionType,
-				wifiInfo[i].RSSI, BSSID, wifiInfo[i].channel,
-				wifiInfo[i].isHidden);
+		WiFi.getNetworkInfo(i, SSID, wifiInfo[i].encryptionType,
+			wifiInfo[i].RSSI, BSSID, wifiInfo[i].channel,
+			wifiInfo[i].isHidden);
 #else
-			WiFi.getNetworkInfo(i, SSID, wifiInfo[i].encryptionType,
-				wifiInfo[i].RSSI, BSSID, wifiInfo[i].channel);
+		WiFi.getNetworkInfo(i, SSID, wifiInfo[i].encryptionType,
+			wifiInfo[i].RSSI, BSSID, wifiInfo[i].channel);
 #endif
-			SSID.toCharArray(wifiInfo[i].ssid, sizeof(wifiInfo[0].ssid));
-		}
-
-		WiFi.mode(WIFI_AP);
-		const IPAddress apIP(192, 168, 4, 1);
-		WiFi.softAPConfig(apIP, apIP, IPAddress(255, 255, 255, 0));
-		WiFi.softAP(cfg::fs_ssid, cfg::fs_pwd, selectChannelForAp());
-		// In case we create a unique password at first start
-		debug_outln_info(F("AP Password is: "), String(WLANPWD));
-
-		DNSServer dnsServer;
-		dnsServer.setErrorReplyCode(DNSReplyCode::NoError);
-		dnsServer.start(53, "*", apIP);							// 53 is port for DNS server
-
-		setup_webserver();
-
-		// 10 minutes timeout for wifi config
-		last_page_load = millis();
-		while (((millis() - last_page_load) < cfg::time_for_wifi_config)) {
-			dnsServer.processNextRequest();
-			server.handleClient();
-#if defined(ESP8266)
-			wdt_reset(); // nodemcu is alive
-#endif
-			yield();
-		}
-
-		// half second to answer last requests
-		last_page_load = millis();
-		while ((millis() - last_page_load) < 500) {
-			dnsServer.processNextRequest();
-			server.handleClient();
-			yield();
-		}
-
-		WiFi.disconnect(true);
-		WiFi.softAPdisconnect(true);
-		WiFi.mode(WIFI_STA);
-
-		dnsServer.stop();
+		SSID.toCharArray(wifiInfo[i].ssid, sizeof(wifiInfo[0].ssid));
 	}
 
+	WiFi.mode(WIFI_AP);
+	const IPAddress apIP(192, 168, 4, 1);
+	WiFi.softAPConfig(apIP, apIP, IPAddress(255, 255, 255, 0));
+	WiFi.softAP(cfg::fs_ssid, cfg::fs_pwd, selectChannelForAp());
+	// In case we create a unique password at first start
+	debug_outln_info(F("AP Password is: "), String(WLANPWD));
+
+	DNSServer dnsServer;
+	// Ensure we don't poison the client DNS cache
+	dnsServer.setTTL(0);
+	dnsServer.setErrorReplyCode(DNSReplyCode::NoError);
+	dnsServer.start(53, "*", apIP);							// 53 is port for DNS server
+
+	setup_webserver();
+
+	// 10 minutes timeout for wifi config
+	last_page_load = millis();
+	while (((millis() - last_page_load) < cfg::time_for_wifi_config) + 500) {
+		dnsServer.processNextRequest();
+		server.handleClient();
+#if defined(ESP8266)
+		wdt_reset(); // nodemcu is alive
+		MDNS.update();
+#endif
+		yield();
+	}
+
+	WiFi.softAPdisconnect(true);
+	WiFi.mode(WIFI_STA);
+
+	dnsServer.stop();
 	delay(100);
 
 	debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
@@ -2414,6 +2404,11 @@ static void connectWifi() {
 	WiFi.begin(cfg::wlanssid, cfg::wlanpwd); // Start WiFI
 
 	debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
+
+	if (MDNS.begin(cfg::fs_ssid)) {
+		MDNS.addService("http", "tcp", 80);
+		MDNS.addServiceTxt("http", "tcp", "PATH", "/config");
+	}
 
 	waitForWifiToConnect(40);
 	debug_outln("", DEBUG_MIN_INFO);
@@ -4320,12 +4315,6 @@ void setup(void) {
 	powerOnTestSensors();
 	logEnabledAPIs();
 	logEnabledDisplays();
-
-	String server_name = F(HOSTNAME_BASE);
-	server_name += esp_chipid;
-	if (MDNS.begin(server_name.c_str())) {
-		MDNS.addService("http", "tcp", 80);
-	}
 
 	delay(50);
 


### PR DESCRIPTION
Remove
some code duplication/indentation errors as well as
ensuring that our captive DNS responses are not cached
by setting TTL to 0.