### PR TITLE
Restore backward compatibility with firmware builds against older arduinojson

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -4,6 +4,10 @@ NRZ-2019-124-B6
 * option to flip OLED output
 * Fix crash on selecting available networks in AP mode
 * add options to disable display of wifi and device infos
+* Code size optimisations
+* Serve config pages incrementally to avoid running out of memory
+* Write more compliant config JSON
+* Advertise as http://airrohr.local/ in AP mode
 
 NRZ-2019-124-B5
 * some comments removed

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -271,7 +271,6 @@ namespace cfg {
 	bool send2fsapp = SEND2FSAPP;
 	bool send2aircms = SEND2AIRCMS;
 	bool send2custom = SEND2CUSTOM;
-	bool send2lora = SEND2LORA;
 	bool send2influx = SEND2INFLUX;
 	bool send2csv = SEND2CSV;
 
@@ -1026,7 +1025,6 @@ static void readConfig() {
 					setBoolFromJSON(send2sensemap);
 					setBoolFromJSON(send2fsapp);
 					setBoolFromJSON(send2aircms);
-					setBoolFromJSON(send2lora);
 					setBoolFromJSON(send2csv);
 					setBoolFromJSON(auto_update);
 					setBoolFromJSON(use_beta);
@@ -1126,7 +1124,6 @@ static void writeConfig() {
 	SetJSON(send2sensemap);
 	SetJSON(send2fsapp);
 	SetJSON(send2aircms);
-	SetJSON(send2lora);
 	SetJSON(send2csv);
 	SetJSON(auto_update);
 	SetJSON(use_beta);
@@ -2591,12 +2588,6 @@ static unsigned long sendLuftdaten(const String& data, const int pin, const __Fl
 
 	return sum_send_time;
 }
-
-/*****************************************************************
- * send data to LoRa gateway                                     *
- *****************************************************************/
-// void send_lora(const String& data) {
-// }
 
 /*****************************************************************
  * send data to mqtt api                                         *
@@ -4148,10 +4139,6 @@ static void logEnabledAPIs() {
 		debug_outln_info(F("Madavi.de"));
 	}
 
-	if (cfg::send2lora) {
-		debug_outln_info(F("LoRa gateway"));
-	}
-
 	if (cfg::send2csv) {
 		debug_outln_info(F("Serial as CSV"));
 	}
@@ -4252,11 +4239,6 @@ static unsigned long sendDataToOptionalApis(const String &data) {
 		sum_send_time += sendData(data_4_influxdb, 0, cfg::host_influx, cfg::port_influx, cfg::url_influx, cfg::ssl_influx, false, basic_auth_influx.c_str(), FPSTR(TXT_CONTENT_TYPE_INFLUXDB));
 	}
 
-	/*		if (send2lora) {
-				debug_outln_info(F("## Sending to LoRa gateway: "));
-				send_lora(data);
-			}
-	*/
 	if (cfg::send2csv) {
 		debug_outln_info(F("## Sending as csv: "));
 		send_csv(data);

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -951,6 +951,17 @@ static void disable_unneeded_nmea() {
 /*****************************************************************
  * read config from spiffs                                       *
  *****************************************************************/
+
+/* backward compatibility for the times when we stored booleans as strings */
+
+static bool boolFromJSON(const DynamicJsonDocument& json, const char* key)
+{
+	if (json[key].is<char*>()) {
+		return !strcmp(json[key].as<char*>(), "true");
+	}
+	return json[key].as<bool>();
+}
+
 static void readConfig() {
 	using namespace cfg;
 	String json_string;
@@ -980,6 +991,7 @@ static void readConfig() {
 						strcpy(version_from_local_config, json["SOFTWARE_VERSION"]);
 					}
 
+#define setBoolFromJSON(key)    if (json.containsKey(#key)) key = boolFromJSON(json, #key);
 #define setFromJSON(key)    if (json.containsKey(#key)) key = json[#key];
 #define strcpyFromJSON(key) if (json.containsKey(#key)) strcpy(key, json[#key]);
 					strcpyFromJSON(current_lang);
@@ -990,42 +1002,42 @@ static void readConfig() {
 					strcpyFromJSON(fs_ssid);
 					strcpyFromJSON(fs_pwd);
 
-					setFromJSON(www_basicauth_enabled);
-					setFromJSON(dht_read);
-					setFromJSON(htu21d_read);
-					setFromJSON(ppd_read);
-					setFromJSON(sds_read);
-					setFromJSON(pms_read);
-					setFromJSON(pms24_read);
-					setFromJSON(pms32_read);
-					setFromJSON(hpm_read);
-					setFromJSON(sps30_read);
-					setFromJSON(bmp_read);
-					setFromJSON(bmp280_read);
-					setFromJSON(bme280_read);
-					setFromJSON(ds18b20_read);
-					setFromJSON(dnms_read);
+					setBoolFromJSON(www_basicauth_enabled);
+					setBoolFromJSON(dht_read);
+					setBoolFromJSON(htu21d_read);
+					setBoolFromJSON(ppd_read);
+					setBoolFromJSON(sds_read);
+					setBoolFromJSON(pms_read);
+					setBoolFromJSON(pms24_read);
+					setBoolFromJSON(pms32_read);
+					setBoolFromJSON(hpm_read);
+					setBoolFromJSON(sps30_read);
+					setBoolFromJSON(bmp_read);
+					setBoolFromJSON(bmp280_read);
+					setBoolFromJSON(bme280_read);
+					setBoolFromJSON(ds18b20_read);
+					setBoolFromJSON(dnms_read);
 					strcpyFromJSON(dnms_correction);
-					setFromJSON(gps_read);
-					setFromJSON(send2dusti);
-					setFromJSON(ssl_dusti);
-					setFromJSON(send2madavi);
-					setFromJSON(ssl_madavi);
-					setFromJSON(send2sensemap);
-					setFromJSON(send2fsapp);
-					setFromJSON(send2aircms);
-					setFromJSON(send2lora);
-					setFromJSON(send2csv);
-					setFromJSON(auto_update);
-					setFromJSON(use_beta);
-					setFromJSON(has_display);
-					setFromJSON(has_sh1106);
-					setFromJSON(has_flipped_display);
-					setFromJSON(has_lcd1602);
-					setFromJSON(has_lcd1602_27);
-					setFromJSON(has_lcd2004_27);
-					setFromJSON(display_wifi_info);
-					setFromJSON(display_device_info);
+					setBoolFromJSON(gps_read);
+					setBoolFromJSON(send2dusti);
+					setBoolFromJSON(ssl_dusti);
+					setBoolFromJSON(send2madavi);
+					setBoolFromJSON(ssl_madavi);
+					setBoolFromJSON(send2sensemap);
+					setBoolFromJSON(send2fsapp);
+					setBoolFromJSON(send2aircms);
+					setBoolFromJSON(send2lora);
+					setBoolFromJSON(send2csv);
+					setBoolFromJSON(auto_update);
+					setBoolFromJSON(use_beta);
+					setBoolFromJSON(has_display);
+					setBoolFromJSON(has_sh1106);
+					setBoolFromJSON(has_flipped_display);
+					setBoolFromJSON(has_lcd1602);
+					setBoolFromJSON(has_lcd1602_27);
+					setBoolFromJSON(has_lcd2004_27);
+					setBoolFromJSON(display_wifi_info);
+					setBoolFromJSON(display_device_info);
 					setFromJSON(debug);
 					setFromJSON(sending_intervall_ms);
 					setFromJSON(time_for_wifi_config);
@@ -1034,14 +1046,14 @@ static void readConfig() {
 						strcpy(senseboxid, "");
 						send2sensemap = 0;
 					}
-					setFromJSON(send2custom);
+					setBoolFromJSON(send2custom);
 					strcpyFromJSON(host_custom);
 					strcpyFromJSON(url_custom);
 					setFromJSON(port_custom);
 					strcpyFromJSON(user_custom);
 					strcpyFromJSON(pwd_custom);
-					setFromJSON(ssl_custom);
-					setFromJSON(send2influx);
+					setBoolFromJSON(ssl_custom);
+					setBoolFromJSON(send2influx);
 					strcpyFromJSON(host_influx);
 					strcpyFromJSON(url_influx);
 					setFromJSON(port_influx);
@@ -1051,7 +1063,7 @@ static void readConfig() {
 					if (strlen(measurement_name_influx) == 0) {
 						strcpy(measurement_name_influx, MEASUREMENT_NAME_INFLUX);
 					}
-					setFromJSON(ssl_influx);
+					setBoolFromJSON(ssl_influx);
 					if (strcmp(host_influx, "api.luftdaten.info") == 0) {
 						strcpy(host_influx, "");
 						send2influx = 0;
@@ -1061,6 +1073,7 @@ static void readConfig() {
 						pms_read = 1;
 						writeConfig();
 					}
+#undef setBoolFromJSON
 #undef setFromJSON
 #undef strcpyFromJSON
 				} else {


### PR DESCRIPTION
Before we switched to store booleans as bool values, we stored them as strings. With the new Arduinojson release any nonempty string is considered true, so we need to explicitly parse
string values now for "true"/"false".