### PR TITLE
[WIP] Suspend wifi radio modem between measurements

### DIFF
--- a/airrohr-firmware/airrohr-cfg.h
+++ b/airrohr-firmware/airrohr-cfg.h
@@ -52,6 +52,7 @@ static constexpr ConfigShapeEntry configShape[] PROGMEM = {
 	Config_Bool(send2csv),
 	Config_Bool(auto_update),
 	Config_Bool(use_beta),
+	Config_Bool(use_sleep),
 	Config_Bool(has_display),
 	Config_Bool(has_sh1106),
 	Config_Bool(has_flipped_display),

--- a/airrohr-firmware/ext_def.h
+++ b/airrohr-firmware/ext_def.h
@@ -208,6 +208,9 @@
 // use beta firmware
 #define USE_BETA 0
 
+// use light sleep
+#define USE_LIGHT_SLEEP 0
+
 // OLED Display SSD1306 connected?
 #define HAS_DISPLAY 0
 

--- a/airrohr-firmware/intl_de.h
+++ b/airrohr-firmware/intl_de.h
@@ -40,6 +40,7 @@ const char INTL_FS_WIFI_NAME[] PROGMEM = "Name";
 const char INTL_MORE_SETTINGS[] PROGMEM ="Weitere Einstellungen";
 const char INTL_AUTO_UPDATE[] PROGMEM = "Auto Update";
 const char INTL_USE_BETA[] PROGMEM = "Lade Beta Versionen";
+const char INTL_USE_SLEEP[] PROGMEM = "Unbenutztes WiFi pausieren";
 const char INTL_DISPLAY[] PROGMEM = "OLED SSD1306";
 const char INTL_SH1106[] PROGMEM = "OLED SH1106";
 const char INTL_FLIP_DISPLAY[] PROGMEM = "OLED Display um 180° drehen";

--- a/airrohr-firmware/intl_template.h
+++ b/airrohr-firmware/intl_template.h
@@ -40,6 +40,7 @@ const char INTL_FS_WIFI_NAME[] PROGMEM = "";
 const char INTL_MORE_SETTINGS[] PROGMEM ="";
 const char INTL_AUTO_UPDATE[] PROGMEM = "";
 const char INTL_USE_BETA[] PROGMEM = "";
+const char INTL_USE_SLEEP[] PROGMEM = "";
 const char INTL_DISPLAY[] PROGMEM = "OLED SSD1306";
 const char INTL_SH1106[] PROGMEM = "OLED SH1106";
 const char INTL_FLIP_DISPLAY[] PROGMEM = "OLED Display Flip";


### PR DESCRIPTION
This reduces energy consumption by about 50% and the
SBC is no longer feeling "warm" when touching it, which
might reduce heating effects on the connected sensors
somewhat.

- [ ] Tested successfully