### PR TITLE
Revert "Lock travis build to platformio < 4.0.0"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - PLATFORMIO_CI_SRC=./
 
 install:
-    - pip install -U 'platformio<4.0.0'
+    - pip install -U platformio
     - platformio update
 
 script:


### PR DESCRIPTION
platformio >= 4.0.0 compatibility has been fixed and it
is much nicer.

This reverts commit 8ec7cf2416d8588a5116c6f5a7e9c91586af30b3.