### PR TITLE
Reduce memory consumption of sendData

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -11,6 +11,7 @@ NRZ-2019-124-B6
 * BMP280/BME280 sensors are merged into one implementation
 * Switch OTA updater two a two-Stage implemenation allowing more than 512kb of sketch size
 * Fix memory corruption when using displays
+* Reduce memory consumption in data sending which allows keeping the HTTP server available
 
 NRZ-2019-124-B5
 * some comments removed

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1202,6 +1202,7 @@ static String form_select_lang() {
 					"<option value='DE'>Deutsch (DE)</option>"
 					"<option value='BG'>Bulgarian (BG)</option>"
 					"<option value='CZ'>Český (CZ)</option>"
+					"<option value='DK'>Dansk (DK)</option>"
 					"<option value='EN'>English (EN)</option>"
 					"<option value='ES'>Español (ES)</option>"
 					"<option value='FR'>Français (FR)</option>"
@@ -1212,6 +1213,8 @@ static String form_select_lang() {
 					"<option value='PT'>Português (PT)</option>"
 					"<option value='RU'>Русский (RU)</option>"
 					"<option value='SE'>Svenska (SE)</option>"
+					"<option value='TR'>Türkçe (TR)</option>"
+					"<option value='UA'>Мова (UA)</option>"
 					"</select>"
 					"</td>"
 					"</tr>");


### PR DESCRIPTION
sendData() had two deep-copy capturing closures, which are
keeping full copies of data and request_headers permanently in memory,
which is extremely wasteful and triggering heap fragmentation.
    
We can simplify the code a bit and also avoid printing the http
reply by default, which removes ~ 200ms request time (waiting for serial).