### PR TITLE
Localize the debug setting descriptions

### DIFF
--- a/airrohr-firmware/html-content.h
+++ b/airrohr-firmware/html-content.h
@@ -73,10 +73,10 @@ const char WEB_ROOT_PAGE_CONTENT[] PROGMEM = "<a href='/values'>{t}</a><br/>\
 <a href='/reset'>{restart}</a><br/>\
 <h4>{debug_setting}</h4><br/>\
 <table style='width:100%;'>\
-<tr><td style='width:25%;'><a href='/debug?lvl=0'>None</a></td>\
-<td style='width:25%;'><a href='/debug?lvl=1'>Error</a></td>\
-<td style='width:25%;'><a href='/debug?lvl=3'>Info</a></td>\
-<td style='width:25%;'><a href='/debug?lvl=5'>Verbose</a></td>\
+<tr><td style='width:25%;'><a href='/debug?lvl=0'>" INTL_NONE "</a></td>\
+<td style='width:25%;'><a href='/debug?lvl=1'>" INTL_ERROR "</a></td>\
+<td style='width:25%;'><a href='/debug?lvl=3'>" INTL_MIN_INFO "</a></td>\
+<td style='width:25%;'><a href='/debug?lvl=5'>" INTL_MAX_INFO "</a></td>\
 </tr><tr>\
 </tr>\
 </table>\

--- a/airrohr-firmware/intl_bg.h
+++ b/airrohr-firmware/intl_bg.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Текущи данни";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Запис и рестарт";
 #define INTL_FIRMWARE "Софтуер версия"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Настройки дебъгването на";
-const char INTL_NONE[] PROGMEM = "изключено";
-const char INTL_ERROR[] PROGMEM = "само грешки";
-const char INTL_WARNING[] PROGMEM = "предупреждения";
-const char INTL_MIN_INFO[] PROGMEM = "минимална информация";
-const char INTL_MED_INFO[] PROGMEM = "средна информация";
-const char INTL_MAX_INFO[] PROGMEM = "пълна информация";
+#define INTL_NONE "изключено"
+#define INTL_ERROR "само грешки"
+#define INTL_WARNING "предупреждения"
+#define INTL_MIN_INFO "минимална информация"
+#define INTL_MED_INFO "средна информация"
+#define INTL_MAX_INFO "пълна информация"
 #define INTL_CONFIG_DELETED "Конфигурацията е изтрита"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Конфигурацията не може да бъде изтрита"
 #define INTL_CONFIG_NOT_FOUND "Конфигурацията не е открита"

--- a/airrohr-firmware/intl_cz.h
+++ b/airrohr-firmware/intl_cz.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Aktuální hodnoty";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Uložit a restartovat";
 #define INTL_FIRMWARE "Firmware verze"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Ladìní nastaveno na";
-const char INTL_NONE[] PROGMEM = "žádný";
-const char INTL_ERROR[] PROGMEM = "chyba";
-const char INTL_WARNING[] PROGMEM = "varování";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "stø. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "žádný"
+#define INTL_ERROR "chyba"
+#define INTL_WARNING "varování"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "stø. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "Config.json smazán"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Config.json nemohl být smazán"
 #define INTL_CONFIG_NOT_FOUND "Config.json nenalezen"

--- a/airrohr-firmware/intl_de.h
+++ b/airrohr-firmware/intl_de.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Aktuelle Werte";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Speichern und neu starten";
 #define INTL_FIRMWARE "Firmware"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Setze Debug auf";
-const char INTL_NONE[] PROGMEM = "none";
-const char INTL_ERROR[] PROGMEM = "error";
-const char INTL_WARNING[] PROGMEM = "warning";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "med. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "none"
+#define INTL_ERROR "error"
+#define INTL_WARNING "warning"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "med. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "Config.json gelöscht"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Config.json konnte nicht gelöscht werden"
 #define INTL_CONFIG_NOT_FOUND "Config.json nicht gefunden"

--- a/airrohr-firmware/intl_dk.h
+++ b/airrohr-firmware/intl_dk.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Aktuelle målværdier";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Gem og genstart";
 #define INTL_FIRMWARE "Firmware"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Debug-indstillinger sat til";
-const char INTL_NONE[] PROGMEM = "none";
-const char INTL_ERROR[] PROGMEM = "error";
-const char INTL_WARNING[] PROGMEM = "warning";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "med. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "none"
+#define INTL_ERROR "error"
+#define INTL_WARNING "warning"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "med. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "Config.json slettet"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Config.json kunne ikke slettes"
 #define INTL_CONFIG_NOT_FOUND "Config.json kunne ikke findes"

--- a/airrohr-firmware/intl_en.h
+++ b/airrohr-firmware/intl_en.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Current data";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Save and restart";
 #define INTL_FIRMWARE "Firmware version"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Debug setting to ";
-const char INTL_NONE[] PROGMEM = "off";
-const char INTL_ERROR[] PROGMEM = "only errors";
-const char INTL_WARNING[] PROGMEM = "warnings";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "mid. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "off"
+#define INTL_ERROR "only errors"
+#define INTL_WARNING "warnings"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "mid. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "Configuration is deleted"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Configuration can not be deleted"
 #define INTL_CONFIG_NOT_FOUND "Configuration not found"

--- a/airrohr-firmware/intl_es.h
+++ b/airrohr-firmware/intl_es.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Datos actuales";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Guardar y reiniciar";
 #define INTL_FIRMWARE "Versión del Firmware"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Ajustar Debug a ";
-const char INTL_NONE[] PROGMEM = "off";
-const char INTL_ERROR[] PROGMEM = "Error";
-const char INTL_WARNING[] PROGMEM = "Advertencia";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "mid. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "off"
+#define INTL_ERROR "Error"
+#define INTL_WARNING "Advertencia"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "mid. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "Configuración fue borrada"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Configuración no puede ser borrada"
 #define INTL_CONFIG_NOT_FOUND "Configuración no encontrada"

--- a/airrohr-firmware/intl_fr.h
+++ b/airrohr-firmware/intl_fr.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Données actuelles";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Sauvegarder et redémarrer";
 #define INTL_FIRMWARE "Firmware"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Paramètres de débogage";
-const char INTL_NONE[] PROGMEM = "aucun";
-const char INTL_ERROR[] PROGMEM = "erreur";
-const char INTL_WARNING[] PROGMEM = "avertissement";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "mid. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "aucun"
+#define INTL_ERROR "erreur"
+#define INTL_WARNING "avertissement"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "mid. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "Le fichier config.json a été effacé."
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Le fichier config.json n\'a pas pu être effacé."
 #define INTL_CONFIG_NOT_FOUND "Le fichier config.json est introuvable."

--- a/airrohr-firmware/intl_it.h
+++ b/airrohr-firmware/intl_it.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Dati attuali";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Salva e riavvia";
 #define INTL_FIRMWARE "Versione firmware"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Imposta debug su";
-const char INTL_NONE[] PROGMEM = "Nessuno";
-const char INTL_ERROR[] PROGMEM = "Errore";
-const char INTL_WARNING[] PROGMEM = "Warning";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "med. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "Nessuno"
+#define INTL_ERROR "Errore"
+#define INTL_WARNING "Warning"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "med. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "Configurazione cancellata"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Impossibile cancellare la configurazione"
 #define INTL_CONFIG_NOT_FOUND "Configurazione non trovata"

--- a/airrohr-firmware/intl_lu.h
+++ b/airrohr-firmware/intl_lu.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Aktuell Wäerter";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Späicheren a nei starten";
 #define INTL_FIRMWARE "Firmware"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Debug setzen op";
-const char INTL_NONE[] PROGMEM = "keng";
-const char INTL_ERROR[] PROGMEM = "fehler";
-const char INTL_WARNING[] PROGMEM = "warnung";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "med. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "keng"
+#define INTL_ERROR "fehler"
+#define INTL_WARNING "warnung"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "med. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "Config.json geläscht"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Config.json konnt net geläscht ginn"
 #define INTL_CONFIG_NOT_FOUND "Config.json net fonnt"

--- a/airrohr-firmware/intl_nl.h
+++ b/airrohr-firmware/intl_nl.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Huidige data";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Opslaan en herstarten";
 #define INTL_FIRMWARE "Firmware-versie"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Debugniveau naar ";
-const char INTL_NONE[] PROGMEM = "Uit";
-const char INTL_ERROR[] PROGMEM = "enkel foutmeldingen";
-const char INTL_WARNING[] PROGMEM = "waarschuwingen";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "mid. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "Uit"
+#define INTL_ERROR "enkel foutmeldingen"
+#define INTL_WARNING "waarschuwingen"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "mid. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "Configuratie is verwijderd"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Configuratie kan niet worden verwijderd"
 #define INTL_CONFIG_NOT_FOUND "Configuratie is niet gevonden"

--- a/airrohr-firmware/intl_pl.h
+++ b/airrohr-firmware/intl_pl.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Obecne wskazania";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Zapisz i zrestartuj";
 #define INTL_FIRMWARE "Wersja firmware"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Ustaw poziom debugowania na ";
-const char INTL_NONE[] PROGMEM = "wyłączony";
-const char INTL_ERROR[] PROGMEM = "tylko błędy";
-const char INTL_WARNING[] PROGMEM = "ostrzeżenia";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "śr. info";
-const char INTL_MAX_INFO[] PROGMEM = "maks. info";
+#define INTL_NONE "wyłączony"
+#define INTL_ERROR "tylko błędy"
+#define INTL_WARNING "ostrzeżenia"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "śr. info"
+#define INTL_MAX_INFO "maks. info"
 #define INTL_CONFIG_DELETED "Usunięto konfigurację"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Konfiguracja nie może zostać usunięta"
 #define INTL_CONFIG_NOT_FOUND "Nie znaleziono konfiguracji"

--- a/airrohr-firmware/intl_pt.h
+++ b/airrohr-firmware/intl_pt.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Dados atuais";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Salvar e reiniciar";
 #define INTL_FIRMWARE "Versão do Firmware"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Ajustar Debug a ";
-const char INTL_NONE[] PROGMEM = "nenhum";
-const char INTL_ERROR[] PROGMEM = "erro";
-const char INTL_WARNING[] PROGMEM = "Advertência";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "mid. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "nenhum"
+#define INTL_ERROR "erro"
+#define INTL_WARNING "Advertência"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "mid. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "A configuração foi apagada"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "A configuração pode ser apagada"
 #define INTL_CONFIG_NOT_FOUND "Configuração não encontrada"

--- a/airrohr-firmware/intl_ru.h
+++ b/airrohr-firmware/intl_ru.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Текущие значения";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Сохранить и перезапустить";
 #define INTL_FIRMWARE "Прошивка"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Настройки отладки";
-const char INTL_NONE[] PROGMEM = "отключена";
-const char INTL_ERROR[] PROGMEM = "только ошибки";
-const char INTL_WARNING[] PROGMEM = "предупреждения";
-const char INTL_MIN_INFO[] PROGMEM = "минимум информации";
-const char INTL_MED_INFO[] PROGMEM = "среднеинформативно";
-const char INTL_MAX_INFO[] PROGMEM = "максимум информации";
+#define INTL_NONE "отключена"
+#define INTL_ERROR "только ошибки"
+#define INTL_WARNING "предупреждения"
+#define INTL_MIN_INFO "минимум информации"
+#define INTL_MED_INFO "среднеинформативно"
+#define INTL_MAX_INFO "максимум информации"
 #define INTL_CONFIG_DELETED "Config.json удалён"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Config.json нельзя удалить"
 #define INTL_CONFIG_NOT_FOUND "Config.json не найден"

--- a/airrohr-firmware/intl_se.h
+++ b/airrohr-firmware/intl_se.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Aktuella mätvärden";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Spara och starta om";
 #define INTL_FIRMWARE "Firmware"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Ställa in debug-läge";
-const char INTL_NONE[] PROGMEM = "none";
-const char INTL_ERROR[] PROGMEM = "error";
-const char INTL_WARNING[] PROGMEM = "warning";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "med. info";
-const char INTL_MAX_INFO[] PROGMEM = "max. info";
+#define INTL_NONE "none"
+#define INTL_ERROR "error"
+#define INTL_WARNING "warning"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "med. info"
+#define INTL_MAX_INFO "max. info"
 #define INTL_CONFIG_DELETED "Config.json borttagen"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Config.json kunde inte tas bort"
 #define INTL_CONFIG_NOT_FOUND "Config.json kunde inte hittas"

--- a/airrohr-firmware/intl_template.h
+++ b/airrohr-firmware/intl_template.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "";
 #define INTL_FIRMWARE ""
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "";
-const char INTL_NONE[] PROGMEM = "";
-const char INTL_ERROR[] PROGMEM = "";
-const char INTL_WARNING[] PROGMEM = "";
-const char INTL_MIN_INFO[] PROGMEM = "";
-const char INTL_MED_INFO[] PROGMEM = "";
-const char INTL_MAX_INFO[] PROGMEM = "";
+#define INTL_NONE ""
+#define INTL_ERROR ""
+#define INTL_WARNING ""
+#define INTL_MIN_INFO ""
+#define INTL_MED_INFO ""
+#define INTL_MAX_INFO ""
 #define INTL_CONFIG_DELETED ""
 #define INTL_CONFIG_CAN_NOT_BE_DELETED ""
 #define INTL_CONFIG_NOT_FOUND ""

--- a/airrohr-firmware/intl_tr.h
+++ b/airrohr-firmware/intl_tr.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Aktüel veriler";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Kaydet ve yeniden bağlat";
 #define INTL_FIRMWARE "Firmware sürümü"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Debug ayarı ";
-const char INTL_NONE[] PROGMEM = "off";
-const char INTL_ERROR[] PROGMEM = "hatalar";
-const char INTL_WARNING[] PROGMEM = "uyarılar";
-const char INTL_MIN_INFO[] PROGMEM = "min. info";
-const char INTL_MED_INFO[] PROGMEM = "ortalama info";
-const char INTL_MAX_INFO[] PROGMEM = "maks. info";
+#define INTL_NONE "off"
+#define INTL_ERROR "hatalar"
+#define INTL_WARNING "uyarılar"
+#define INTL_MIN_INFO "min. info"
+#define INTL_MED_INFO "ortalama info"
+#define INTL_MAX_INFO "maks. info"
 #define INTL_CONFIG_DELETED "Konfigürasyon silindi"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Konfigürasyon silinemiyor"
 #define INTL_CONFIG_NOT_FOUND "Konfigürasyon bulunamadı"

--- a/airrohr-firmware/intl_ua.h
+++ b/airrohr-firmware/intl_ua.h
@@ -76,12 +76,12 @@ const char INTL_CURRENT_DATA[] PROGMEM = "Поточні показники";
 const char INTL_SAVE_AND_RESTART[] PROGMEM = "Зберегти та перезавантажити";
 #define INTL_FIRMWARE "Версія мікропрограми"
 const char INTL_DEBUG_SETTING_TO[] PROGMEM = "Зневадження: ";
-const char INTL_NONE[] PROGMEM = "вимкнено";
-const char INTL_ERROR[] PROGMEM = "лише помилки";
-const char INTL_WARNING[] PROGMEM = "попередження";
-const char INTL_MIN_INFO[] PROGMEM = "мінімум інформації";
-const char INTL_MED_INFO[] PROGMEM = "помірно інформації";
-const char INTL_MAX_INFO[] PROGMEM = "максимум інформації";
+#define INTL_NONE "вимкнено"
+#define INTL_ERROR "лише помилки"
+#define INTL_WARNING "попередження"
+#define INTL_MIN_INFO "мінімум інформації"
+#define INTL_MED_INFO "помірно інформації"
+#define INTL_MAX_INFO "максимум інформації"
 #define INTL_CONFIG_DELETED "Конфігурацію видалено"
 #define INTL_CONFIG_CAN_NOT_BE_DELETED "Конфігурацію не можна видалити"
 #define INTL_CONFIG_NOT_FOUND "Конфігурацію не знайдено"


### PR DESCRIPTION
Instead of hardcoding the english names, use the INTL_
variants which makes the root page look slighly more uniform.
Using compile-time string concatenation to reduce code size
impact.