### PR TITLE
Reduce code duplication in configuration reading

### DIFF
--- a/airrohr-firmware/airrohr-cfg.h
+++ b/airrohr-firmware/airrohr-cfg.h
@@ -2,7 +2,8 @@
 enum ConfigEntryType {
 	Config_Type_Bool,
 	Config_Type_UInt,
-	Config_Type_String
+	Config_Type_String,
+	Config_Type_Password
 };
 
 struct ConfigShapeEntry {
@@ -19,14 +20,15 @@ struct ConfigShapeEntry {
 static constexpr ConfigShapeEntry configShape[] PROGMEM = {
 #define Config_Bool(varname) { Config_Type_Bool, #varname, &cfg::varname }
 #define Config_String(varname) { Config_Type_String, #varname, cfg::varname }
+#define Config_Password(varname) { Config_Type_Password, #varname, cfg::varname }
 #define Config_UInt(varname) { Config_Type_UInt, #varname, &cfg::varname }
 	Config_String(current_lang),
 	Config_String(wlanssid),
-	Config_String(wlanpwd),
+	Config_Password(wlanpwd),
 	Config_String(www_username),
-	Config_String(www_password),
+	Config_Password(www_password),
 	Config_String(fs_ssid),
-	Config_String(fs_pwd),
+	Config_Password(fs_pwd),
 	Config_Bool(www_basicauth_enabled),
 	Config_Bool(dht_read),
 	Config_Bool(htu21d_read),
@@ -68,18 +70,19 @@ static constexpr ConfigShapeEntry configShape[] PROGMEM = {
 	Config_String(url_custom),
 	Config_UInt(port_custom),
 	Config_String(user_custom),
-	Config_String(pwd_custom),
+	Config_Password(pwd_custom),
 	Config_Bool(ssl_custom),
 	Config_Bool(send2influx),
 	Config_String(host_influx),
 	Config_String(url_influx),
 	Config_UInt(port_influx),
 	Config_String(user_influx),
-	Config_String(pwd_influx),
+	Config_Password(pwd_influx),
 	Config_String(measurement_name_influx),
 	Config_Bool(ssl_influx),
 
 #undef Config_Bool
+#undef Config_Password
 #undef Config_String
 #undef Config_Int
 };

--- a/airrohr-firmware/defines.h
+++ b/airrohr-firmware/defines.h
@@ -8,14 +8,13 @@
 #define SSID_BASENAME "airRohr-"
 #define HOSTNAME_BASE "airRohr-"
 
+#define LEN_CFG_PASSWORD 65
+
 #define LEN_WLANSSID 35				// credentials for wifi connection
-#define LEN_WLANPWD 65
 
 #define LEN_WWW_USERNAME 65			// credentials for basic auth of server internal website
-#define LEN_WWW_PASSWORD 65
 
 #define LEN_FS_SSID 33				// credentials for sensor access point mode
-#define LEN_FS_PWD 65
 
 #define LEN_DNMS_CORRECTION 10
 
@@ -24,13 +23,11 @@
 #define LEN_HOST_INFLUX 100
 #define LEN_URL_INFLUX 100
 #define LEN_USER_INFLUX 65
-#define LEN_PWD_INFLUX 65
 #define LEN_MEASUREMENT_NAME_INFLUX 100
 
 #define LEN_HOST_CUSTOM 100
 #define LEN_URL_CUSTOM 100
 #define LEN_USER_CUSTOM 65
-#define LEN_PWD_CUSTOM 65
 
 #define MAX_PORT_DIGITS 5
 


### PR DESCRIPTION
The Password and Char handling can also be done via the configShape
descriptions by adding an additional type "Password" and handling
it accordingly. In order to avoid buffer overflows we're setting
all sizes for password cfg fields to the same variable (it was
that way already anyway). Similarly for other strings we can do the
same, however we still need to fix up the max sizes to avoid
a buffer overflow.

Saves about 1.3kb of Flash.