### PR TITLE
Fix for #513 : checking presence of Si7021 in case HTU21D is not dete…

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,3 +1,6 @@
+NRZ-2019-124-B9
+* Fix for #513 : checking if Si7021 is present in case HTU21D is not detected
+
 NRZ-2019-124-B8
 * bug fixes
 * translation updates

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -105,7 +105,7 @@
  *
  ************************************************************************/
 // increment on change
-#define SOFTWARE_VERSION_STR "NRZ-2019-124-B8.1"
+#define SOFTWARE_VERSION_STR "NRZ-2019-124-B9"
 const String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 /*****************************************************************

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -105,7 +105,7 @@
  *
  ************************************************************************/
 // increment on change
-#define SOFTWARE_VERSION_STR "NRZ-2019-124-B8"
+#define SOFTWARE_VERSION_STR "NRZ-2019-124-B8.1"
 const String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 /*****************************************************************
@@ -128,6 +128,7 @@ const String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 #if defined(ESP8266)
 #include <FS.h>                     // must be first
+#include <WiFiClientSecureAxTLS.h>
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
 #include <ESP8266mDNS.h>
@@ -3935,8 +3936,17 @@ static void powerOnTestSensors() {
 	if (cfg::htu21d_read) {
 		debug_outln_info(F("Read HTU21D..."));
 		if (!htu21d.begin()) {
-			debug_outln_error(F("Check HTU21D wiring"));
-			htu21d_init_failed = true;
+      debug_outln_info(F("Read Si7021 replacement for HTU21D ..."));
+      Wire.beginTransmission(HTU21DF_I2CADDR);
+      Wire.write(HTU21DF_READREG);
+      Wire.endTransmission();
+      Wire.requestFrom(HTU21DF_I2CADDR, 1);
+      if( Wire.read() == 0x3A){
+         debug_outln_error(F("Found Si7120 instead of HTU21D"));
+      } else {
+        debug_outln_error(F("Check HTU21D wiring"));
+			  htu21d_init_failed = true;
+      }
 		}
 	}
 


### PR DESCRIPTION
…cted. Added include for axTLS.

Si7021 is compatible with HTU21D, but it returns 0x3A instead of 0x2 on I2C command 0xE7, thats why the .begin() function failed