### PR TITLE
Pin5 of PMS7003 should be disconnected - connecting it to GND turns off the sensor.

### DIFF
--- a/airrohr-firmware/Readme.md
+++ b/airrohr-firmware/Readme.md
@@ -162,7 +162,7 @@ Pinout PMS7003:
 
 * Pin  1/2 (VCC) -> VU
 * Pin  3/4 (GND) -> GND
-* Pin  5 (RESET) -> GND
+* Pin  5 (RESET) -> unused
 * Pin  6 (NC)    -> unused
 * Pin  7 (RX)    -> Pin D2 (GPIO4)
 * Pin  8 (NC)    -> unused


### PR DESCRIPTION
It took me quite some time to check the specsheet and disconnect the Pin5 from GND.