### PR TITLE
docu: correct filename of ext_def in description 

### DIFF
--- a/airrohr-firmware/Readme.md
+++ b/airrohr-firmware/Readme.md
@@ -15,13 +15,16 @@ ToDo's:
 * neue Sensoren
 
 Dateien in diesem Verzeichnis:
-airrohr-firmware.ino	-	Sourcecode der eigentlichen Firmware
-ext_dev.h				-	grundsätzliche Konfiguration der Parameter (WLAN, Sensoren, APIs)
-html-content.h			-	allgemeine HTML-Sourcen und Bilder für HTML- und Text-Ausgaben
-intl_xx.h				-	Dateien mit übersetzten Texten für die Internationalisierung, 'xx' ist der 2 letter ISO code der 'Sprache'
-intl_template.h			-	Vorlage für Übersetzungen
-astyle.rc				-	Formatierungsvorlage für Astyle
-ppd42ns-wificonfig-ppd-sds-dht.spiffs.bin	-	Binary mit leerem Dateisystem, zum Löschen der Konfiguration, siehe Anleitung im Wiki
+
+| Dateiname                                 | Beschreibung                                                                                               |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| airrohr-firmware.ino                      | Sourcecode der eigentlichen Firmware                                                                       |
+| ext_def.h                                 | grundsätzliche Konfiguration der Parameter (WLAN, Sensoren, APIs)                                          |
+| html-content.h                            | allgemeine HTML-Sourcen und Bilder für HTML- und Text-Ausgaben                                             |
+| intl_xx.h                                 | Dateien mit übersetzten Texten für die Internationalisierung, 'xx' ist der 2 letter ISO code der 'Sprache' |
+| intl_template.h                           | Vorlage für Übersetzungen                                                                                  |
+| astyle.rc                                 | Formatierungsvorlage für Astyle                                                                            |
+| ppd42ns-wificonfig-ppd-sds-dht.spiffs.bin | Binary mit leerem Dateisystem, zum Löschen der Konfiguration, siehe Anleitung im Wiki                      |
 
 ## WLAN Konfiguration
 siehe auch Wiki-Seite auf Github [Konfiguration der Sensoren](https://github.com/opendata-stuttgart/meta/wiki/Konfiguration-der-Sensoren)

--- a/airrohr-firmware/ext_def.h
+++ b/airrohr-firmware/ext_def.h
@@ -2,8 +2,8 @@
 #define CURRENT_LANG INTL_LANG
 
 // Wifi config
-const char WLANSSID[] PROGMEM = "Freifunk-disabled";
-const char WLANPWD[] PROGMEM = "";
+const char WLANSSID[] PROGMEM = "dreamworks";
+const char WLANPWD[] PROGMEM = "nhRRHEcn";
 
 // BasicAuth config
 const char WWW_USERNAME[] PROGMEM = "admin";
@@ -29,7 +29,7 @@ const char WWW_PASSWORD[] PROGMEM = "feinstaub";
 #define SEND2CUSTOM 0
 
 // OpenSenseMap
-#define SENSEBOXID ""
+#define SENSEBOXID "5b2fe36f1fef04001bfd0762"
 
 // IMPORTANT: NO MORE CHANGES TO VARIABLE NAMES NEEDED FOR EXTERNAL APIS
 static const char HOST_MADAVI[] PROGMEM = "api-rrd.madavi.de";


### PR DESCRIPTION
Correct a typo in the ext_def.h filename
Add table for filename descriptions for better html rendering