### PR TITLE
Do not validate firmware update server certificate when system time i…

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,3 +1,7 @@
+NRZ-2019-126-B4
+* Try to configure system time from 3 different NTP sources
+* When system time is invalid, disable TLS verification
+
 NRZ-2019-126-B3
 * OTA updater validates loader checksums prior update
 * Maintain config setting backups and fall back if current version is corrupt

--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,6 +1,7 @@
 NRZ-2019-126-B4
 * Try to configure system time from 3 different NTP sources
 * When system time is invalid, disable TLS verification
+* Use TLS for Feinstaub-App reporting
 
 NRZ-2019-126-B3
 * OTA updater validates loader checksums prior update

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1099,6 +1099,7 @@ static void createLoggerConfigs() {
 	loggerConfigs[LoggerSensemap].destport = PORT_SENSEMAP;
 	loggerConfigs[LoggerSensemap].session = new BearSSL::Session;
 	loggerConfigs[LoggerFSapp].destport = PORT_FSAPP;
+	loggerConfigs[LoggerFSapp].session = new BearSSL::Session;
 	loggerConfigs[Loggeraircms].destport = PORT_AIRCMS;
 	loggerConfigs[LoggerInflux].destport = cfg::port_influx;
 	if (cfg::send2influx && cfg::ssl_influx) {

--- a/airrohr-firmware/ext_def.h
+++ b/airrohr-firmware/ext_def.h
@@ -63,7 +63,7 @@ static const char URL_SENSEMAP[] PROGMEM = "/boxes/{v}/data?luftdaten=1";
 
 static const char HOST_FSAPP[] PROGMEM = "h2801469.stratoserver.net";
 static const char URL_FSAPP[] PROGMEM = "/data.php";
-#define PORT_FSAPP 80
+#define PORT_FSAPP 443
 
 static const char HOST_AIRCMS[] PROGMEM = "doiot.ru";
 static const char URL_AIRCMS[] PROGMEM = "/php/sensors.php?h=";

--- a/airrohr-firmware/ext_def.h
+++ b/airrohr-firmware/ext_def.h
@@ -76,6 +76,10 @@ static const char FW_DOWNLOAD_HOST[] PROGMEM = "firmware.sensor.community";
 
 static const char FW_2ND_LOADER_URL[] PROGMEM = OTA_BASENAME "/loader-002.bin";
 
+static const char NTP_SERVER_1[] PROGMEM = "0.pool.ntp.org";
+static const char NTP_SERVER_2[] PROGMEM = "1.pool.ntp.org";
+static const char NTP_SERVER_3[] PROGMEM = "2.pool.ntp.org";
+
 // define own API
 static const char HOST_CUSTOM[] PROGMEM = "192.168.234.1";
 static const char URL_CUSTOM[] PROGMEM = "/data.php";


### PR DESCRIPTION
…s wrong (Fixes #536)

Before we downloaded the firmware unencrypted.. it seems time
is difficult to obtain. Lets not lock ourselves out.

Also print the NTP servers that are being used.