### PR TITLE
Read SDS011 firmware date/uuid string only once

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,3 +1,6 @@
+NRZ-2019-126-B6
+* Read SDS011 version once on startup
+
 NRZ-2019-126-B5
 * Rename Luftdaten.info to Sensors.Community everywhere
 * Report the submitted wifi signal quality level in the web UI

--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,5 +1,6 @@
 NRZ-2019-126-B6
 * Read SDS011 version once on startup
+* Put software serial edge detection work within loop
 
 NRZ-2019-126-B5
 * Rename Luftdaten.info to Sensors.Community everywhere

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -90,7 +90,7 @@
  *
  ************************************************************************/
 // increment on change
-#define SOFTWARE_VERSION_STR "NRZ-2019-126-B5"
+#define SOFTWARE_VERSION_STR "NRZ-2019-126-B6"
 const String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 /*****************************************************************
@@ -537,6 +537,7 @@ String last_data_string;
 int last_signal_strength;
 
 String esp_chipid;
+String last_value_SDS_version;
 
 unsigned long last_page_load = millis();
 
@@ -817,9 +818,12 @@ static String SDS_version_date() {
 	char buffer;
 	int value;
 	int len = 0;
-	String s, version_date, device_id;
+	String version_date, device_id;
+	String s(last_value_SDS_version);
 	int checksum_is = 0;
 	bool checksum_ok = false;
+
+	if (!cfg::sds_read || s.length()) return s;
 
 	debug_outln_verbose(FPSTR(DBG_TXT_END_READING), FPSTR(DBG_TXT_SDS011_VERSION_DATE));
 
@@ -895,7 +899,7 @@ static String SDS_version_date() {
 		if (len > 2) { checksum_is += value; }
 		len++;
 		if (len == 10 && checksum_ok) {
-			s = version_date + '(' + device_id + ')';
+			s = last_value_SDS_version = version_date + '(' + device_id + ')';
 			debug_outln_info(F("SDS version date : "), version_date);
 			debug_outln_info(F("SDS device ID: "), device_id);
 			len = 0;
@@ -3354,8 +3358,7 @@ static bool fwDownloadStream(WiFiClientSecure& client, const String& url, Stream
 	int bytes_written = -1;
 
 	http.setTimeout(20 * 1000);
-	const String SDS_version = cfg::sds_read ? SDS_version_date() : "";
-	http.setUserAgent(SOFTWARE_VERSION + ' ' + esp_chipid + ' ' + SDS_version + ' ' +
+	http.setUserAgent(SOFTWARE_VERSION + ' ' + esp_chipid + ' ' + SDS_version_date() + ' ' +
 				 String(cfg::current_lang) + ' ' + String(CURRENT_LANG) + ' ' +
 				 String(cfg::use_beta ? "BETA" : ""));
 

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -4486,6 +4486,7 @@ void loop(void) {
 	yield();
 #if defined(ESP8266)
 	MDNS.update();
+	serialSDS.perform_work();
 #endif
 
 	if (sample_count % 500 == 0) {


### PR DESCRIPTION
This string doesn't change during the uptime of a sensor, so
we can read it only once. unfortunately we can't cache it
in powerOnSensors() because the OTA update is launched before
powering on sensors.