### PR TITLE
Revert "Software serial: compress edge detection buffer as soon as po…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - PLATFORMIO_CI_SRC=./
 
 install:
-   - pip install -U 'platformio<4.0.0'
+   - pip install -U platformio
    - platformio update
 
 script:

--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,6 +1,5 @@
 NRZ-2019-126-B6
 * Read SDS011 version once on startup
-* Put software serial edge detection work within loop
 * Discard power-on self-test dust sensor measurements
 * Do not store WiFi station credentials in SDK protected flash
 * Switch to ArduinoJson 6.13

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -4508,7 +4508,6 @@ void loop(void) {
 	yield();
 #if defined(ESP8266)
 	MDNS.update();
-	serialSDS.perform_work();
 #endif
 
 	if (sample_count % 500 == 0) {


### PR DESCRIPTION
…ssible"

The current tip of tree is really unstable on SDS011, and
this patch is the most likely candidate. lets revert it.

This reverts commit 3876637ab56716a7785636956481802bbb1f4054.