### PR TITLE
Turn off modem sleep

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -2316,7 +2316,9 @@ static void connectWifi() {
 #if defined(ESP8266)
 	// Enforce Rx/Tx calibration
 	system_phy_set_powerup_option(1);
-	WiFi.setOutputPower(20.5f);
+    // 20dBM == 100mW == max tx power allowed in europe
+	WiFi.setOutputPower(20.0f);
+	WiFi.setSleepMode(WIFI_NONE_SLEEP);
 	WiFi.setPhyMode(WIFI_PHY_MODE_11N);
 	delay(100);
 #endif


### PR DESCRIPTION
Until we can update the Arduino core 2.6.0 (which is hopefully soon)
with the newer xtensa toolchain, it seems the best bet is to
reduce wifi sleeping. Also high transmit power can interfere with
the flash reading which can cause instability.

https://github.com/esp8266/Arduino/issues/5998#issuecomment-549068473
https://github.com/esp8266/Arduino/issues/6471