### PR TITLE
Update to Arduino Core 2.6.1

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -4,6 +4,7 @@ NRZ-2019-126-B6
 * Do not store WiFi station credentials in SDK protected flash
 * Switch to ArduinoJson 6.13
 * show SDS011 manufacturing date in values HTML page
+* Update to Arduino Core 2.6.1, including many fixes for SSL, WiFi and SoftwareSerial
 
 NRZ-2019-126-B5
 * Rename Luftdaten.info to Sensors.Community everywhere

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -4107,13 +4107,17 @@ static void logEnabledDisplays() {
 
 static void time_is_set (void) {
 	sntp_time_is_set = true;
+
+	time_t now = time(nullptr);
+	debug_outln_info(F("SNTP sync finished: "), ctime(&now));
+	twoStageOTAUpdate();
+	last_update_attempt = millis();
 }
 
-static bool acquireNetworkTime() {
+static void setupNetworkTime() {
 	// server name ptrs must be persisted after the call to configTime because internally
 	// the pointers are stored see implementation of lwip sntp_setservername()
 	static char ntpServer1[18], ntpServer2[18], ntpServer3[18];
-	debug_outln_info(F("Setting time using SNTP"));
 #if defined(ESP8266)
 	settimeofday_cb(time_is_set);
 #endif
@@ -4121,18 +4125,6 @@ static bool acquireNetworkTime() {
 	strcpy_P(ntpServer2, NTP_SERVER_2);
 	strcpy_P(ntpServer3, NTP_SERVER_3);
 	configTime(0, 0, ntpServer1, ntpServer2, ntpServer3);
-	for (int retryCount = 0; retryCount < 5 + 3 * 30; ++retryCount) {
-		if (sntp_time_is_set) {
-			time_t now = time(nullptr);
-			debug_outln_info(ctime(&now));
-			return true;
-		}
-		delay(500);
-		debug_out(".", DEBUG_MIN_INFO);
-	}
-	time_t now = time(nullptr);
-	debug_outln_info(ctime(&now));
-	return false;
 }
 
 static unsigned long sendDataToOptionalApis(const String &data) {
@@ -4231,15 +4223,11 @@ void setup(void) {
 	init_display();
 	init_lcd();
 	display_debug(F("Connecting to"), String(cfg::wlanssid));
+	setupNetworkTime();
 	connectWifi();
-	bool got_ntp = acquireNetworkTime();
-	debug_out(F("\nNTP time "), DEBUG_MIN_INFO);
-	debug_outln_info(got_ntp ? FPSTR(DBG_TXT_FOUND) : FPSTR(DBG_TXT_NOT_FOUND));
-	twoStageOTAUpdate();
 	setup_webserver();
 	createLoggerConfigs();
 	debug_outln_info(F("\nChipId: "), esp_chipid);
-
 
 	if (cfg::gps_read) {
 #if defined(ESP8266)
@@ -4281,6 +4269,15 @@ void loop(void) {
 	String result_GPS, result_DNMS;
 
 	unsigned sum_send_time = 0;
+	static unsigned sntpWaitTimes = 0;
+
+	// Wait with operations until NTP is set
+	if (!sntp_time_is_set) {
+		if (sntpWaitTimes++ < 5 + 3 * 30) {
+			delay(50);
+			return;
+		}
+	}
 
 	act_micro = micros();
 	act_milli = millis();

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -84,6 +84,10 @@
  *                                                                      *
  ************************************************************************
  *
+ * latest mit lib 2.6.1
+ * DATA:    [====      ]  40.7% (used 33316 bytes from 81920 bytes)
+ * PROGRAM: [=====     ]  49.3% (used 514788 bytes from 1044464 bytes)
+
  * latest mit lib 2.5.2
  * DATA:    [====      ]  39.4% (used 32304 bytes from 81920 bytes)
  * PROGRAM: [=====     ]  48.3% (used 504812 bytes from 1044464 bytes)

--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -82,7 +82,8 @@ extra_scripts = platformio_script.py
 # When the requirement for Arduino Core is raised, this
 # needs to be adjusted to the matching version from
 # https://github.com/platformio/platform-espressif8266/releases
-platform_version = espressif8266@2.2.3
+# platform_version = espressif8266@2.2.3
+platform_version = https://github.com/Jason2866/platform-espressif8266.git#core_2_6_1
 platform_version_esp32 = espressif32@1.11.1 ; using Arduino core 1.0.4
 
 [env]


### PR DESCRIPTION
Ets intr lock nest (#6484)
This great fixing PR has - among others - closed the old infamous #2330
Add LittleFS as an optional filesystem w/subdirectories, API compatible w/SPIFFS and SDFS
(but not on-flash-format compatible) (#5511)
Build System
Update esptool reset method (#6429)
Fix Python3 errors for device tests (#6670)
Dynamically find the Python3 dir on Windows (#6646)
esptool-2.7 (#6634)
CI: trusty (u14.04) -> bionic (u18.04) (#6627)
remove esptool.py --trace option (#6606)
prepare alpha channel release builder (#6512)
Move all PSTRs to own section, allow string dedup (#6565)
use arduino IDE stable in CI (#6572)
Add 20/26MHz Flash frequencies for slow/cheap flash chips on the Generic ESP board (#6552)
Add segment size printout to standard build process (#6525)
Fix tool name to point to proper JSON entry (#6513)
Run makecorever.py before specific prebuild hooks. (#6504)
Add Win32 build to CI system (#6493)
Add OSX build to CI, fix OSX builds (#6492)
Fix the python3 directory so scripts work on Win32 (#6472)
Move all scripts and documentation to Python3 (#6378)
fix arduino builder command line (#6461)
Prevent rewriting core_version.h if content unchanged (#6414)
esptool: 3M-baud serial upload speed (#6399)
Move to -std=g++11 from -std=c++11 (#6339)
Upgrade to 2.5.0-4 toolchain w/improved pgm_read_x, C++ exceptions (#6273)
Clean tools key of obsolete version on next release (#6258)
esptool.py: disable 9600bauds in menu for flash upload serial speed (#6292)
Prepare signing before sketch is compiled (#6287)
Refactored to avoid compiler warning (#6278)
Make SPIFFS be an integer number of blocks (#5989, #6537)
Updater signature validation - format incompatible w/RFC8017 (#6250)
Fix device test environment variables (#6229)
Expand gitignore to cover files created by Visual Micro (#6231)
Update mklittlefs to match library (#6230)
filter weird characters from esp output to python (#6226)
Add some more CI tests for String::replace (#6193)
IDE menu info: change SPIFFS -> FS and show max OTA size (#6159)
emulation on host updates (#6210, #6211, #6248, #6327, #6342, #6507)
Core
Add missing time.h include, use relative include path on time.h includes (#6730)
Save 16 bytes RAM by placing esp8266_gpioToFn (core_esp8266_wiring_digital.cpp) array in PROGMEM (#6703)
precache() - preload code into the flash cache (#6628, #6674)
Double I2C read in one transaction skips a clock pulse (#5528) (#6654)
Move cont_run/cont_yield out of IRAM (#6617)
NTP-TZ-DST example: list SNTP servers (#6611)
Remove duplication and incompatible declarations in sntp.h (#6610)
cleanups in ESPClass (#6608)
Cleanup base64::encode functions (#6607)
use a scheduled function for settimeofday_cb (#6600)
Fix pgm_read_float_unaligned macro (#6593)
Base64::encode : const correctness / String by reference passing (#6581)
Replace ASM block w/C macro for PSTR (#6577)
Speed up empty String creation slightly (#6573)
const correctness / String by reference passing cleanups (#6571)
Remove duplicated sha1 implementation (Fixes #6568) (#6569)
Add typedef for putc1, fn_putc1_t. (#6550)
Add time to filesystem API (#6544)
Add memmove_P, use it in String to ensure F() safety (#6514)
Support FS update in two steps (#6505)
Add ::updateBaudRate(unsigned long baud) to change the baudrate after begin was called (#6494)
Update UART selection for Boot ROM ets_putc, when debug port is selected. (#6489)
Wakeup delayed scheduling (#6485)
Inline ESP::getCycleCount() to make it safe to call from ISRs (#6477)
move timer functions to iram (#6466)
Allow Print::println() to work with PROGMEM strings (#6450)
Update core with upstream umm_malloc (#6438)
Remove ROM routines from libc.a, save progmem (#6432)
Fix reverse dependency core Updater -> library ESP8266WiFi (#6398)
ensure consistency for gdb hooks signatures (#6391)
Uncouple uart from GDBStub library (#6390)
fix _min and _max macros (#6374)
time: import IANA timezone definitions, expose SNTP API (#6373)
Refactor HardwareSerial.cpp for consistent use of PolledTimeout (#6371)
wstring: fix concatenation from flash (#6368)
enable puya support by default (can be disabled with -DPUYA_SUPPORT=0) (#6362, #6619)
Preserve prior bitrate for I2S begin (#6349)
Add a FS::check() optional method (#6340)
tools: fixed bug to select signed bin (#6334)
exceptions: optionally enforce c++ standards (#6333)
Reduce the IRAM usage of I2C code by 600-1500 bytes (#6326)
Clear updater state on any error (#6325)
Add using fs::SPIFFSConfig to FS.h (#6324)
Don't throw exceptions from operator new by default (#6312)
Make delay() and loop_end() weak functions (#6306)
Added memory fence to xt_rsil() (#6301)
Fix for future GCC 9.1 warnings (except Ticker.h, gdbstub) (#6298)
Create (set/is)empty methods for String class (#6293)
Fix raise_exception() (#6288)
proposed umm_malloc improvements (#6274)
Clean up code to build under GCC7, fix pgm_read_unaligned (#6270)
Clean up trivial gcc -wextra warnings (#6254)
using std::nothrow instead of malloc (#6251)
Do not call yield() from timedRead() or timedPeek() when _timeout is set to 0. (#6242)
Put InterruptLock (from interrupts.h) into namespace esp8266 to fix now and future (#6225)
Move umm_malloc back to IRAM (#6161)
Make SSO support \0s, use memmove, add test (#6155)
Add FS::info64 call for filesystems > 4GB (#6154)
Bugfix: attach interrupt (#6049) (#6048)
add regular scheduled functions (#6039, #6137, #6147, #6158, #6214, #6228, #6233)
Implementation of a generic CallBackList (#5710)
Serial.flush modification (#5293)
Style
Style (#6653)
Allman style: mDNS (#6629)
SDK
sync with upstream NONOS-SDK branch 2.2.x (#6257, #6272, #6672, #6724)
Boards
board filter support (+ iTead sonoff, ESP-Mx boards) (#6643)
Adds SparkFun Blynk Board (#6713)
Fix espduino verbose upload (#6426)
Allow use of LED16 for generic boards (#6343)
Library - ESP8266WiFi
Add wait loop at the end of WiFi::mode (+refactor can_yield) (#6721)
ClientContext: restore use of two different pending booleans for connect and write #6483
standardizes processing of _delaying in lwIP callbacks (remove assert) (#6460)
lwIP-1.4: use fixed locking functions (#6455)
ClientContext: break timeout delays also on error while writing or connecting (#6454)
new network feature: NAPT (widely known as NAT) (#6360)
Experimental: add new WiFi (pseudo) modes: WIFI_SHUTDOWN & WIFI_RESUME (#6356)
udp remote pbuf helper: honor fragmented packets (#6222, #6263)
TCP connect and send delay fix (#6213)
lwip2: fix setting static ip address (#6194)
Add timeout to STA::waitForConnectResult (#5371)
added public cleanAPlist() function (#4107)
Library - ESP8266WiFi (SSL/TLS)
Fix WiFiClientSecure::available() blocking on dropped connections (#6449)
Set method _connectSSL as protected (#6424)
SSL: Fix Crash with basic ciphers (#6402)
Update to latest BearSSL (#6337)
SSL: Add a dump of received FP and CERT when in debug mode (#6300)
Update axtls libs with fix for #6260 (#6262)
Fix mixup with boolean/bitwise or for BSSL probing (#6252)
Add an EC keyed certificat to BearSSL Server example (#6202)
Obey the BASIC_SSL request for TLS servers (#6187)
Added BR_OPT_NO_RENEGOTIATION flag to forbid TLS renegotiation (#6165)
64 bytes more free by moving DES init constants to flash (#6160)
Save 484 bytes of heap foe BSSL applications (#6157)
Add basic canary check to BSSL stack thunk (#6156)
Expand BSSL stack to 5750 bytes (#6153)
Make CertStore natively use File interface (#6131)
Library - ESP8266WebServer
Fix trivial extra "\n" on web update success (#6350)
Add HTTP_HEAD to HTTPMethod and parse it (#6413)
Add plain char* signatures WebServer::sendContent (#6341)
webserver: restore legacy request handler (#6321)
allow for authentication with H(A1) with example (#6020)
Convert ESP8266WebServer* into templatized model (#5982)
fallback onto index.html if index.htm fails (#2614)
POST web server example (#2705)
Library - ESP8266HTTPClient
Fix build with -DHTTPCLIENT_1_1_COMPATIBLE=0 (#6597)
Fix setURL() handling of path-only parameters (#6570)
BasicHttpsClient: Updated demo certificate fingerprint (#6462)
Bugfix/esp8266 http client (#6176)
Infinite loop while passing File(FS.h) resolved (#5038)
Added possibility of sending POST with empty payload (#4275)
Library - mDNS
fix legacy unicast responses (#6613)
Clean up remaining non-LeaMDNS diffs from gcc4.8 to gcc7.2 (#6279)
fix random crash on startup (#6261)
restriction to a single interface (#6224)
Library - SPI
Set SPI_HAS_TRANSACTION to 1 (#6591)
Spi slave improvments (#6580)
SPI: wrong value for setFrequency() (#6409)
Library - Ticker
Ticker: Fix callback casting. (#6282)
Ticker: Use placement new for ETSTimer - no heap fragmentation (#6164)
The use of bind in Ticker.h is prone to type inference failure (#6129)
Libraries
EspSoftwareSerial release 5.4.0 with performance/error rate improvement in TX (#6722)
Update EEPROM.cpp (#6556, #6599)
Put more string literals into PROGMEM (#6588)
add or improve some debug messages (#6508)
OTA: fixed no "OK" ACK for Signed Update (#6351)
FS: Update LittleFS/SdFat to current project head (#6345)
ConfigFile: Updated Example to use ArduinoJson6 (#6203)
DNSServer: Add support for newer mobile OS changes. (#5529)
ESP8266HTTPUpdate: Added Chip ID into HTTP header in lib (#3877)
ESP8266HTTPUpdate: Allow Filesystem update (#3732)
Documentation
Re-wording of ATOMIC_FS_UPDATE documentation (#6693)
Update installing.rst (#6625)
Installing (#6624)
Minor FS documentation change from #2904 (#6563)
Add interrupt section to docs (#6560)
Add info about installing python3 on Mac, Linux (#6558)
Update EEPROM library documentation (#6548)
Edited OTA readme, added Stream Interface snippet (#6487)
Fix the number of examples (#6407)
Grammar edits in documentation (#6401)
fix documented parameter (#6392)
Update WiFiServer docs for ::write(all clients) (#6338)
Fix typo in doc (#6313)
Minor doc update, "How to make a PR" link (#6297)
add documentation to scheduled functions (#6234)
Fix editing, typos and grammatical errors (#6207)
Document ISRs need ICACHE_RAM_ATTR before them (#6141)