### PR TITLE
Update Readme's and switch to English only

### DIFF
--- a/airrohr-firmware/Contributing.md
+++ b/airrohr-firmware/Contributing.md
@@ -1,0 +1,91 @@
+# Contributing Guidelines
+
+
+## IMPORTANT Information
+
+All new development changes should be done as pull requests against the **beta** branch.
+
+The default **master** branch is only used as a source reference for the
+currently active (enrolled) firmware version.
+
+## Build Instrutions
+
+### Recommended Build using PlatformIO
+
+Current revisions of airRohr firmware are being tested and released by using
+[PlatformIO Core](https://platformio.org/install/cli). The included `platformio.ini`
+file is used to install and update all required dependencies into the correct
+and required version. While the dependencies are listed here in more detail, the
+authoritative versions and references are in the platformio.ini file.
+
+PlatformIO provides [many IDE integrations](https://platformio.org/install/integration). 
+
+
+### Build using Arduino IDE
+
+As a fall back it should be possible to build the firmware via the Arduino IDE. This
+method is only a fallback over the PlatformIO. Any submission to the repository
+must pass building and work with a PlatformIO based build.
+
+Settings needed:
+* [Arduino IDE](https://www.arduino.cc/en/Main/Software)  (Version 1.8.10) (GNU Lesser General Public License v2.1)
+* [ESP8266 für Arduino](http://arduino.esp8266.com/stable/package_esp8266com_index.json) (Version 2.6.2)
+
+Configuration Settings in Arduino IDE:
+* Board: NodeMCU 1.0 (ESP-12E Module)
+* CPU Frequency: 160MHz
+* Flash Size: 4M (3M SPIFFS)
+* Debug Port: Disabled
+* Debug Level: NoAssert-NDEBUG
+* lwIP Variant: v2.0 Lower memory
+* VTables. Flash
+* Erase Flash: Only Sketch
+
+Libraries used from ESP8266 Arduino:
+* Wire (GNU Lesser General Public License v2.1)
+* FS (GNU Lesser Public License >=2.1)
+* ESP8266WiFi (GNU Lesser Public License >=2.1)
+* ESP8266WebServer (GNU Lesser Public License >=2.1)
+* ESP8266HTTPClient (GNU Lesser Public License >=2.1)
+* DNSServer (GNU Lesser Public License >=2.1)
+
+Additional Libraries needed for building:
+* [ArduinoJson](https://github.com/bblanchon/ArduinoJson) (6.13.0) (MIT)
+* [Adafruit BMP085 library](https://github.com/adafruit/Adafruit-BMP085-Library) (1.0.1) (BSD)
+* [Adafruit HTU21DF library](https://github.com/adafruit/Adafruit_HTU21DF_Library) (1.0.2) (BSD)
+* [Adafruit SHT31 library](https://github.com/adafruit/Adafruit_SHT31)(1.1.5) (BSD)
+* [DallasTemperature](https://github.com/milesburton/Arduino-Temperature-Control-Library) (3.8.0)
+* [ESP8266 and ESP32 Oled driver for SSD1306 display](https://github.com/squix78/esp8266-oled-ssd1306) (4.1.0) (MIT)
+* [OneWire](www.pjrc.com/teensy/td_libs_OneWire.html) (2.3.4)
+* [LiquidCrystal I2C](https://github.com/marcoschwartz/LiquidCrystal_I2C) (1.1.2)
+* [EspSoftwareSerial](https://github.com/plerup/espsoftwareserial)(6.3.0)
+* [TinyGPS++](http://arduiniana.org/libraries/tinygpsplus/) (1.0.2) (GNU Lesser Public License >=2.1)
+
+
+## Source Layout
+
+| Dateiname                                 | Beschreibung                                                                                               |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `airrohr-firmware.ino`                      | Sourcecode der eigentlichen Firmware                                                                       |
+| `ext_def.h`                                 | grundsätzliche Konfiguration der Parameter (WLAN, Sensoren, APIs)                                          |
+| `html-content.h`                            | allgemeine HTML-Sourcen und Bilder für HTML- und Text-Ausgaben                                             |
+| `intl_xx.h`                                 | Dateien mit übersetzten Texten für die Internationalisierung, 'xx' ist der 2 letter ISO code der 'Sprache' |
+| `intl_template.h`                           | Vorlage für Übersetzungen                                                                                  |
+| `astyle.rc`                                 | Formatierungsvorlage für Astyle                                                                            |
+| `ppd42ns-wificonfig-ppd-sds-dht.spiffs.bin` | Binary mit leerem Dateisystem, zum Löschen der Konfiguration, siehe Anleitung im Wiki                      |
+
+
+## Translations
+
+For new translations copy the file `intl_template.h` and rename it to `intl_xx.h`, where `xx` is the ISO-3166-2 two letter country code. This file contains all strings used for
+output seen by normal users. Only debug output is remaining EN by default.
+
+Please take look at the existing translations and try to adhere and improve
+consistency accross and within the particular translation.
+
+
+## TODOs
+
+* [Bug fixes](https://github.com/opendata-stuttgart/sensors-software/issues?q=is%3Aopen+label%3Abug+sort%3Aupdated-desc)
+* [Enhancements (New Sensors, Larger Efforts)](https://github.com/opendata-stuttgart/sensors-software/issues?q=is%3Aopen+label%3Aenhancement+sort%3Aupdated-desc)
+* Optimisations

--- a/airrohr-firmware/Readme.md
+++ b/airrohr-firmware/Readme.md
@@ -1,115 +1,58 @@
-IMPORTANT: All pull requests should be made to the beta branch. The master branch is for the actual stable version. 
+# airRohr Sensor Firmware for PPD42NS, SDS011, DHT22, BMP180, BMP/E 280, NEO-6M and many more
 
+## Features:
+* many environmental and air quality sensors can be used concurrently
+* Integration in Sensor.Community (formerly Luftdaten.Info)
+* Configuration via HTTP in local WiFi or with a Sensor-as Access-Point
+* Support for OLED- and LCD-Displays (SSD1306, SH1106 and LCD1602, LCD2004)
+* Wide selection of API integrations for measurement reporting
+* Ability to print measurements as CSV via USB-serial
+* Used with ESP8266 (NodeMCU v2/v3 and compatible) and ESP32 (experimental)
 
-# Version für Sensoren PPD42NS, SDS011, DHT22, BMP180, BMP/E 280, NEO-6M und weitere (siehe Konfigurationsseite)
+## Contributing
 
-Features:
-* gleichzeitiger Betrieb mehrerer Sensoren
-* Konfiguration über WLAN (Sensor als Access Point) möglich
-* Unterstützung von OLED-Displays mit SSD1306, SH1106 und LCD1602, LCD2004
-* Auswahl der API(s), an welche die Daten gesendet werden, inklusive der Möglichkeit, die Daten als CSV über USB auszugeben
-* nutzbar mit ESP8266 (NodeMCU und kompatible Boards)
+Please refer to [Contributing README](./Contributing.md) for details.
 
-ToDo's:
-* Optimierungen (eigentlich immer)
-* neue Sensoren
+## WiFi configuration
+For German Version see: [Konfiguration der Sensoren](https://github.com/opendata-stuttgart/meta/wiki/Konfiguration-der-Sensoren)
 
-Dateien in diesem Verzeichnis:
+If a (previously) configured WiFi is not reachable within 20 seconds after power-on,
+the firmware flips itself into AP mode and creates a WiFi network in the form `airRohr-\[Sensor-ID\]`.
 
-| Dateiname                                 | Beschreibung                                                                                               |
-| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| airrohr-firmware.ino                      | Sourcecode der eigentlichen Firmware                                                                       |
-| ext_def.h                                 | grundsätzliche Konfiguration der Parameter (WLAN, Sensoren, APIs)                                          |
-| html-content.h                            | allgemeine HTML-Sourcen und Bilder für HTML- und Text-Ausgaben                                             |
-| intl_xx.h                                 | Dateien mit übersetzten Texten für die Internationalisierung, 'xx' ist der 2 letter ISO code der 'Sprache' |
-| intl_template.h                           | Vorlage für Übersetzungen                                                                                  |
-| astyle.rc                                 | Formatierungsvorlage für Astyle                                                                            |
-| ppd42ns-wificonfig-ppd-sds-dht.spiffs.bin | Binary mit leerem Dateisystem, zum Löschen der Konfiguration, siehe Anleitung im Wiki                      |
+This WiFi network is by default unencrypted. When a client connects to this, it will get
+redirected to the sensors web server `http://192.168.4.1/` which allows initial configuration.
 
-## WLAN Konfiguration
-siehe auch Wiki-Seite auf Github [Konfiguration der Sensoren](https://github.com/opendata-stuttgart/meta/wiki/Konfiguration-der-Sensoren)
+Configurable is
+* WiFi Access Point to use
+* Options for measurements (Sensors to poll, intervals..)
+* APIs to send the measurements
 
-Wenn das vorgegebene WLAN nach 20 Sekunden nicht erreichbar ist, wird ein Access-Point eingerichtet, der über "Feinstaubsensor-\[Sensor-ID\]" erreichbar ist. Nach dem Verbinden zu diesem Accesspoint sollten alle Anfragen auf die Konfigurationsseite umgeleitet werden. Direkte Adresse der Seite ist http://192.168.4.1/ .
+The unencrypted Access Point for initial configuration will turn itself off after about
+10 minutes. In order to reactivate please power cycle the board.
 
-Konfigurierbar sind:
-* WLAN-Name und Passwort
-* Auszulesende Sensoren
-* Ziele für den Versand der Daten
+## Debug via USB-Serial
 
-Nach 10 Minuten sollte der Access-Point wieder deaktiviert werden (funktioniert zur Zeit noch nicht stabil).
+Connecting/Powering via a computer USB will provide USB serial with the settings 9600 baud 8N1.
+By default the sensor will provide human readable debug information of configurable granularity
+there.
 
+## Save as CSV
 
-## Speichern als CSV
+All measurements can also be read as CSV via USB-Serial when using the USB port in the
+settings 9600 Baud 8N1. In order to avoid interfering of debug options (see earlier section)
+set debug to None in the configuration.
 
-Die Daten können als CSV via USB ausgegeben werden. Dafür sollte sowohl in ext_def.h als auch in der WLAN-Konfiguration Debug auf 0 gesetzt werden, damit die ausgegebenen Daten nur noch die Sensordaten sind. Beim Neustart des ESP8266 erscheinen dann nur noch ein paar wenige Zeichen, die den Startzustand darstellen.
 
 ## Wiring
 
-* SDS and DHT wiring: [https://raw.githubusercontent.com/opendata-stuttgart/meta/master/files/nodemcu-v3-schaltplan-sds011.jpg](https://raw.githubusercontent.com/opendata-stuttgart/meta/master/files/nodemcu-v3-schaltplan-sds011.jpg)
+![https://raw.githubusercontent.com/opendata-stuttgart/meta/master/files/nodemcu-v3-schaltplan-sds011.jpg](https://raw.githubusercontent.com/opendata-stuttgart/meta/master/files/nodemcu-v3-schaltplan-sds011.jpg)
 
-## Benötigte Software (in Klammern getestete Version und die Art der Lizenz):
+Please refer to the [Pinout of NodeMCU v2 and v3](https://github.com/opendata-stuttgart/meta/wiki/Pinouts-NodeMCU-v2,-v3) for much more detailed information about the individual pin functions.
 
-* [Arduino IDE](https://www.arduino.cc/en/Main/Software)  (Version 1.8.10) (GNU Lesser General Public License v2.1)
-* [ESP8266 für Arduino](http://arduino.esp8266.com/stable/package_esp8266com_index.json) (Version 2.6.2)
-
-
-### Einstellungen Arduino IDE
-
-* Board: NodeMCU 1.0 (ESP-12E Module)
-* CPU Frequency: 160MHz
-* Flash Size: 4M (3M SPIFFS)
-
-Ab "ESP für Arduino 2.5.2":
-* Debug Port: Disabled
-* Debug Level: NoAssert-NDEBUG
-* lwIP Variant: v2.0 Lower memory
-* VTables. Flash
-* Erase Flash: Only Sketch
-* in der Datei platform.txt die Zeile
-  'build.float=-u _printf_float -u _scanf_float'
-  ändern in
-  'build.float='
-
-### Verwendete Bibliotheken (für ESP8266):
-
-In Arduino enthalten:
-* Wire (GNU Lesser General Public License v2.1)
-
-In ESP8266 für Arduino IDE enthalten:
-* FS (GNU Lesser Public License >=2.1)
-* ESP8266WiFi (GNU Lesser Public License >=2.1)
-* ESP8266WebServer (GNU Lesser Public License >=2.1)
-* ESP8266HTTPClient (GNU Lesser Public License >=2.1)
-* DNSServer (GNU Lesser Public License >=2.1)
-
-Installierbar über Arduino IDE (Menü Sketch -> Bibliothek einbinden -> Bibliotheken verwalten, in Klammern die getestete Version und die Art der Lizenz):
-* [ArduinoJson](https://github.com/bblanchon/ArduinoJson) (6.13.0) (MIT)
-* [Adafruit BMP085 library](https://github.com/adafruit/Adafruit-BMP085-Library) (1.0.1) (BSD)
-* [Adafruit HTU21DF library](https://github.com/adafruit/Adafruit_HTU21DF_Library) (1.0.2) (BSD)
-* [Adafruit SHT31 library](https://github.com/adafruit/Adafruit_SHT31)(1.1.5) (BSD)
-* [DallasTemperature](https://github.com/milesburton/Arduino-Temperature-Control-Library) (3.8.0)
-* [ESP8266 and ESP32 Oled driver for SSD1306 display](https://github.com/squix78/esp8266-oled-ssd1306) (4.1.0) (MIT)
-* [OneWire](www.pjrc.com/teensy/td_libs_OneWire.html) (2.3.4)
-* [LiquidCrystal I2C](https://github.com/marcoschwartz/LiquidCrystal_I2C) (1.1.2)
-* [EspSoftwareSerial](https://github.com/plerup/espsoftwareserial)(6.3.0)
-
-Manuell zu installieren:
-* [TinyGPS++](http://arduiniana.org/libraries/tinygpsplus/) (1.0.2) (GNU Lesser Public License >=2.1)
-
-
-Bis Version NRZ-2016-15:
-* [DHT](https://github.com/adafruit/DHT-sensor-library)
-  (`DHT.cpp` und `DHT.h` downloaden und in das Softwareverzeichnis kopieren)
-
-Ich hoffe, alle Bibliotheken erwischt zu haben. Falls beim Kompilieren eine Bibliothek fehlt, bitte als [Issue](https://github.com/opendata-stuttgart/sensors-software/issues/) melden. Ich trage dann die Infos nach.
-
-## Anschluss der Sensoren
-
-Beim Anschluss von Sensoren mit 5V bitte die Board-Version beachten. NodeMCU v3 liefert 5V an `VU`, Version 2 fehlt dieser Anschluss und `VIN` kann dafür genutzt werden.
-
-### SDS011
-* Pin 1 (TX)   -> Pin D1 (GPIO5)
-* Pin 2 (RX)   -> Pin D2 (GPIO4)
+### SDS011 (serial)
+**Note**: Serial connections are always crossed (RX on one side is connected with TX on other side)
+* Pin 1 (TX)   -> (RX) Pin D1 (GPIO5)
+* Pin 2 (RX)   -> (TX) Pin D2 (GPIO4)
 * Pin 3 (GND)  -> GND
 * Pin 4 (2.5m) -> unused
 * Pin 5 (5V)   -> VU
@@ -174,17 +117,20 @@ Pinout:
 * Pin 7	(RX)     -> Pin D2 (GPIO4)
 * Pin 8 (GND)    -> GND
 
-### BMP180 / BMP280 / BME280 (I2C)
+### BMP180 / BMP280 / BME280 / HTU21D / SHT3x (I2C)
 * VCC  ->  Pin 3V3
 * GND  ->  Pin GND
 * SCL  ->  Pin D4 (GPIO2)
 * SDA  ->  Pin D3 (GPIO0)
 
-### HTU21D / Sensirion SHT3x (I2C)
-* VCC  ->  Pin 3V3
-* GND  ->  Pin GND
-* SCL  ->  Pin D4 (GPIO2)
-* SDA  ->  Pin D3 (GPIO0)
+### SPS30 (I2C, 5V)
+Pinout:
+   1 2 3 4 5
+* Pin 1 (5V)     -> Pin VU/VIN
+* Pin 2 (SDA)    -> Pin D3 (GPIO0)
+* Pin 3 (SCL)    -> Pin D4 (GPIO2)
+* Pin 4 (SEL)    -> Pin GND
+* Pin 5 (GND)    -> Pin GND
 
 ### LCD1602 (I2C, 5V - check your version)
 * VCC  ->  Pin VU
@@ -198,24 +144,26 @@ Pinout:
 * SCL  ->  Pin D4 (GPIO2)
 * SDA  ->  Pin D3 (GPIO0)
 
-### GPS NEO 6M (seriell) ACHTUNG: Läuft sehr instabil
-Strom und Masse vom Board. (GND und üblicherweise 3,3v, vorher prüfen/Anleitung, Beschreibung GPS!) 
-TX (senden) und RX (empfangen) werden gekreuzt verkabelt! 
+### GPS NEO 6M (serial)
+VCC and GND can be provided by board board (use 3.3v!)
+
+**Note**: Serial connections are always crossed (RX on one side is connected with TX on other side)
+
 * TX von Neo -> Pin D5 (RX) 
 * RX von Neo -> Pin D6 (TX) 
 
-### Luftdaten.info API "Pins"
-Bei Aktivierung von mehreren Sensoren, z.B. "gleichzeitig" DHT22 und PPD42NS, benötigt die API zur Zuordnung der Sensorwerte die Angabe eines Pins, an dem der Sensor (virtuell) angeschlossen ist.
-Diese Firmware definiert die Pins für die verschiedenenen Sensoren wie folgt:
+## Luftdaten.info API "Pins"
+
+For use of multiple sensors with Luftdaten.info, you need to specify a *virtual* API Pin
+for the use of Luftdaten.info in the Luftdaten.info sensor registration. The firmware
+uses the following API pins hardcoded. These match what the Luftdaten.info expect and
+will use by default when selecting the correct sensor model.
+
+* HPM/PMS/SDS011/SPS30 => Pin 1
+* BMP180/BMP280 => Pin 3
 * PPD42NS => Pin 5
-* DHT22 => Pin 7
-* SDS011 => Pin 1
-* BMP180 => Pin 3
-* BMP280 => Pin 3
-* BME280 => Pin 11
+* DHT22/HTU21D/SHT3x => Pin 7
 * GPS(Neo-6M) => Pin 9
-
-
-## Translations
-For new translations copy the file intl_template.h and rename it to intl_<2-letter-code>.h, where <2-letter-code> is the ISO-3166-2 2 letter country code. This file contains all strings used for output seen by normal users. Only debug output is (or better should be) English by default.  
-Please take look at the existing translations. This should show you how it works ;-)
+* BME280 => Pin 11
+* DS18B20 => Pin 13
+* DNMS +> Pin 15

--- a/readme.md
+++ b/readme.md
@@ -1,20 +1,27 @@
 firmware master branch: [![Build Status](https://travis-ci.com/opendata-stuttgart/sensors-software.svg?branch=master)](https://travis-ci.com/opendata-stuttgart/sensors-software)  
 firmware beta branch: [![Build Status](https://travis-ci.com/opendata-stuttgart/sensors-software.svg?branch=beta)](https://travis-ci.com/opendata-stuttgart/sensors-software)  
 
-# Software for hardware prototypes
+# Software for Sensor.Community / Luftdaten.Info Sensor
 
-## esp8266-arduino  
+## airrohr-firmware
 
-currently used and maintained version
+The maintained main firmware for the Luftdaten.Info Sensor. 
 
-## arduino
+## airrohr-update-loader
 
-code for all sensors used as prototypes.
+A transitional firmware which will look for a firmware file
+stored on SPIFFS to replace itself with for next reboot
+or do an endless loop of panic LED blinking if this fails.
+
+This allows to do an Over-the-air (OTA) procedure on setups
+that have a 1M/3M split layout (rather the more modern 2M/2M)
+for firmwares larger than 512k (up to ~ 740k).
 
 # Directories 
 
 * BeginnersGuide	Beginners guide to ESP programming with Arduino code
-* airrohr-firmware	currently the used and maintained versions (2017-05-23)
+* airrohr-....          currently used versions (2017-05-23+)
+* airrohr-update-...	currently used for OTA (2019-08-30+)
 * apiclients	clients for the dusti API and other APIs
 * arduino	native arduino code
 * esp8266-lua	nodemcu firmware code, lua scripts (not maintained after change to arduino)


### PR DESCRIPTION
The previous versions were a weird mix of German and english.
To better separate usage and contributing information, a
separate contributing.md has been introduced for airrohr-firmware.