### PR TITLE
Avoid buffer overflow on scan failure

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -5,6 +5,7 @@ NRZ-2020-130-B2
 * Accept larger flash sizes also as compatible
 * Switch to a tab based configuration page
 * Skip initialization of display's when not configured
+* Delay OneWire initialization until configured
 
 NRZ-2020-130-B1
 * next beta version

--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -3,6 +3,7 @@ NRZ-2020-130-B2
 * Only do OTA after sensor measurements are finished
 * Remove uninitialized memory read in NTP handling
 * Accept larger flash sizes also as compatible
+* Switch to a tab based configuration page
 
 NRZ-2020-130-B1
 * next beta version

--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,5 +1,6 @@
 NRZ-2020-130-B1
 * next beta version
+* Avoid crash on WiFi network scan failure (Related to #615)
 
 NRZ-2020-129
 online since 2020-01-07

--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -4,6 +4,7 @@ NRZ-2020-130-B2
 * Remove uninitialized memory read in NTP handling
 * Accept larger flash sizes also as compatible
 * Switch to a tab based configuration page
+* Skip initialization of display's when not configured
 
 NRZ-2020-130-B1
 * next beta version

--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -6,6 +6,7 @@ NRZ-2020-130-B2
 * Switch to a tab based configuration page
 * Skip initialization of display's when not configured
 * Delay OneWire initialization until configured
+* Fix bulgarian translation error (Fixes #622)
 
 NRZ-2020-130-B1
 * next beta version

--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,6 +1,11 @@
+NRZ-2020-130-B2
+* Avoid crash on WiFi network scan failure (Related to #615)
+* Only do OTA after sensor measurements are finished
+* Remove uninitialized memory read in NTP handling
+* Accept larger flash sizes also as compatible
+
 NRZ-2020-130-B1
 * next beta version
-* Avoid crash on WiFi network scan failure (Related to #615)
 
 NRZ-2020-129
 online since 2020-01-07

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -4128,7 +4128,7 @@ static void logEnabledDisplays() {
 static void setupNetworkTime() {
 	// server name ptrs must be persisted after the call to configTime because internally
 	// the pointers are stored see implementation of lwip sntp_setservername()
-	static char ntpServer1[18], ntpServer2[18], ntpServer3[18];
+	static char ntpServer1[18], ntpServer2[18];
 #if defined(ESP8266)
 	settimeofday_cb([]() {
 		if (!sntp_time_set) {
@@ -4142,7 +4142,7 @@ static void setupNetworkTime() {
 #endif
 	strcpy_P(ntpServer1, NTP_SERVER_1);
 	strcpy_P(ntpServer2, NTP_SERVER_2);
-	configTime(0, 0, ntpServer1, ntpServer2, ntpServer3);
+	configTime(0, 0, ntpServer1, ntpServer2);
 }
 
 static unsigned long sendDataToOptionalApis(const String &data) {

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -3893,21 +3893,21 @@ static void display_values() {
 }
 
 /*****************************************************************
- * Init OLED display                                             *
+ * Init LCD/OLED display                                         *
  *****************************************************************/
 static void init_display() {
-	display.init();
-	display_sh1106.init();
-	if (cfg::has_flipped_display) {
-		display.flipScreenVertically();
-		display_sh1106.flipScreenVertically();
-	}
-}
-
-/*****************************************************************
- * Init LCD display                                              *
- *****************************************************************/
-static void init_lcd() {
+    if (cfg::has_display) {
+        display.init();
+        if (cfg::has_flipped_display) {
+            display.flipScreenVertically();
+        }
+    }
+    if (cfg::has_sh1106) {
+        display_sh1106.init();
+        if (cfg::has_flipped_display) {
+            display_sh1106.flipScreenVertically();
+        }
+    }
     if (cfg::has_lcd1602) {
         lcd_1602 = new LiquidCrystal_I2C(0x3f, 16, 2);
     }
@@ -4262,7 +4262,6 @@ void setup(void) {
 
 	init_config();
 	init_display();
-	init_lcd();
 	setupNetworkTime();
 	connectWifi();
 	setup_webserver();

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -369,7 +369,7 @@ Adafruit_SHT31 sht3x;
 /*****************************************************************
  * DS18B20 declaration                                            *
  *****************************************************************/
-OneWire oneWire(ONEWIRE_PIN);
+OneWire oneWire;
 DallasTemperature ds18b20(&oneWire);
 
 /*****************************************************************
@@ -4079,6 +4079,7 @@ static void powerOnTestSensors() {
 	}
 
 	if (cfg::ds18b20_read) {
+		oneWire.begin(ONEWIRE_PIN);
 		ds18b20.begin();									// Start DS18B20
 		debug_outln_info(F("Read DS18B20..."));
 	}

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -4243,7 +4243,7 @@ void setup(void) {
 	WiFi.persistent(false);
 
 	debug_outln_info(F("airRohr: " SOFTWARE_VERSION_STR "/"), String(CURRENT_LANG));
-	if ((airrohr_selftest_failed = !ESP.checkFlashConfig(true) /* after 2.7.0 update: || !ESP.checkFlashCRC() */)) {
+	if ((airrohr_selftest_failed = !ESP.checkFlashConfig() /* after 2.7.0 update: || !ESP.checkFlashCRC() */)) {
 		debug_outln_error(F("ERROR: SELF TEST FAILED!"));
 		SOFTWARE_VERSION += F("-STF");
 	}

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -4326,14 +4326,6 @@ void loop(void) {
 	}
 	last_micro = act_micro;
 
-	if (msSince(time_point_device_start_ms) > DURATION_BEFORE_FORCED_RESTART_MS) {
-		sensor_restart();
-	}
-
-	if (msSince(last_update_attempt) > PAUSE_BETWEEN_UPDATE_ATTEMPTS_MS) {
-		twoStageOTAUpdate();
-		last_update_attempt = act_milli;
-	}
 
 	if (cfg::sps30_read && ( !sps30_init_failed)) {
 		if ((msSince(starttime) - SPS30_read_timer) > SPS30_WAITING_AFTER_LAST_READ) {
@@ -4520,6 +4512,17 @@ void loop(void) {
 			WiFi_error_count++;
 			WiFi.reconnect();
 			waitForWifiToConnect(20);
+		}
+
+		// only do a restart after finishing sending
+		if (msSince(time_point_device_start_ms) > DURATION_BEFORE_FORCED_RESTART_MS) {
+			sensor_restart();
+		}
+
+		// time for a OTA attempt?
+		if (msSince(last_update_attempt) > PAUSE_BETWEEN_UPDATE_ATTEMPTS_MS) {
+			twoStageOTAUpdate();
+			last_update_attempt = act_milli;
 		}
 
 		// Resetting for next sampling

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -2253,11 +2253,19 @@ static void wifiConfig() {
 
 	WiFi.disconnect(true);
 	debug_outln_info(F("scan for wifi networks..."));
-	count_wifiInfo = WiFi.scanNetworks(false /* scan async */, true /* show hidden networks */);
-	delete [] wifiInfo;
-	wifiInfo = new struct_wifiInfo[count_wifiInfo];
+	int8_t scanReturnCode = WiFi.scanNetworks(false /* scan async */, true /* show hidden networks */);
+	if (scanReturnCode < 0) {
+		debug_outln_error(F("WiFi scan failed. Treating as empty. "));
+		count_wifiInfo = 0;
+	}
+	else {
+		count_wifiInfo = (uint8_t) scanReturnCode;
+	}
 
-	for (int i = 0; i < count_wifiInfo; i++) {
+	delete [] wifiInfo;
+	wifiInfo = new struct_wifiInfo[std::max(count_wifiInfo, (uint8_t) 1)];
+
+	for (unsigned i = 0; i < count_wifiInfo; i++) {
 		String SSID;
 		uint8_t* BSSID;
 

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -60,7 +60,7 @@
 #include <pgmspace.h>
 
 // increment on change
-#define SOFTWARE_VERSION_STR "NRZ-2020-130-B1"
+#define SOFTWARE_VERSION_STR "NRZ-2020-130-B2"
 String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 /*****************************************************************

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1348,8 +1348,23 @@ static void webserver_config_send_body_get(String& page_content) {
 	};
 
 	debug_outln_info(F("begin webserver_config_body_get ..."));
-	page_content += F("<form method='POST' action='/config' style='width:100%;'>\n<b>" INTL_WIFI_SETTINGS "</b><br/>");
-	debug_outln_info(F("ws: config page 1"));
+	page_content += F("<form method='POST' action='/config' style='width:100%;'>\n"
+	"<input class='radio' id='one' name='group' type='radio' checked>"
+    "<input class='radio' id='two' name='group' type='radio'>"
+    "<input class='radio' id='three' name='group' type='radio'>"
+    "<input class='radio' id='four' name='group' type='radio'>"
+    "<div class='tabs'>"
+	"<label class='tab' id='tab1' for='one'>" INTL_WIFI_SETTINGS "</label>"
+	"<label class='tab' id='tab2' for='two'>");
+	page_content += FPSTR(INTL_MORE_SETTINGS);
+	page_content += F("</label>"
+		"<label class='tab' id='tab3' for='three'>");
+	page_content += FPSTR(INTL_SENSORS);
+	page_content += F("</label>"
+		"<label class='tab' id='tab4' for='four'>APIs"
+		"</label></div><div class='panels'>"
+		"<div class='panel' id='panel1'>");
+
 	if (wificonfig_loop) {  // scan for wlan ssids
 		page_content += F("<div id='wifilist'>" INTL_WIFI_NETWORKS "</div><br/>");
 	}
@@ -1389,6 +1404,25 @@ static void webserver_config_send_body_get(String& page_content) {
 		// Paginate page after ~ 1500 Bytes
 		server.sendContent(page_content);
 	}
+
+	page_content = tmpl(FPSTR(WEB_DIV_PANEL), String(2));
+
+	add_form_checkbox(Config_has_display, FPSTR(INTL_DISPLAY));
+	add_form_checkbox(Config_has_sh1106, FPSTR(INTL_SH1106));
+	add_form_checkbox(Config_has_flipped_display, FPSTR(INTL_FLIP_DISPLAY));
+	add_form_checkbox(Config_has_lcd1602_27, FPSTR(INTL_LCD1602_27));
+	add_form_checkbox(Config_has_lcd1602, FPSTR(INTL_LCD1602_3F));
+
+	// Paginate page after ~ 1500 Bytes
+	server.sendContent(page_content);
+	page_content = emptyString;
+
+	add_form_checkbox(Config_has_lcd2004_27, FPSTR(INTL_LCD2004_27));
+	add_form_checkbox(Config_has_lcd2004, FPSTR(INTL_LCD2004_3F));
+	add_form_checkbox(Config_display_wifi_info, FPSTR(INTL_DISPLAY_WIFI_INFO));
+	add_form_checkbox(Config_display_device_info, FPSTR(INTL_DISPLAY_DEVICE_INFO));
+
+	server.sendContent(page_content);
 	page_content = FPSTR(WEB_BR_LF_B);
 	page_content += F(INTL_FIRMWARE "</b>&nbsp;");
 	add_form_checkbox(Config_auto_update, FPSTR(INTL_AUTO_UPDATE));
@@ -1412,29 +1446,8 @@ static void webserver_config_send_body_get(String& page_content) {
 	page_content += FPSTR(TABLE_TAG_CLOSE_BR);
 
 	server.sendContent(page_content);
-	page_content = FPSTR(WEB_BR_LF_B);
-	page_content += FPSTR(INTL_MORE_SETTINGS);
-	page_content += FPSTR(WEB_B_BR);
 
-	add_form_checkbox(Config_has_display, FPSTR(INTL_DISPLAY));
-	add_form_checkbox(Config_has_sh1106, FPSTR(INTL_SH1106));
-	add_form_checkbox(Config_has_flipped_display, FPSTR(INTL_FLIP_DISPLAY));
-	add_form_checkbox(Config_has_lcd1602_27, FPSTR(INTL_LCD1602_27));
-	add_form_checkbox(Config_has_lcd1602, FPSTR(INTL_LCD1602_3F));
-
-	// Paginate page after ~ 1500 Bytes
-	server.sendContent(page_content);
-	page_content = emptyString;
-
-	add_form_checkbox(Config_has_lcd2004_27, FPSTR(INTL_LCD2004_27));
-	add_form_checkbox(Config_has_lcd2004, FPSTR(INTL_LCD2004_3F));
-	add_form_checkbox(Config_display_wifi_info, FPSTR(INTL_DISPLAY_WIFI_INFO));
-	add_form_checkbox(Config_display_device_info, FPSTR(INTL_DISPLAY_DEVICE_INFO));
-
-	server.sendContent(page_content);
-	page_content = FPSTR(WEB_BR_LF_B);
-	page_content += FPSTR(INTL_SENSORS);
-	page_content += FPSTR(WEB_B_BR);
+	page_content = tmpl(FPSTR(WEB_DIV_PANEL), String(3));
 	add_form_checkbox_sensor(Config_sds_read, FPSTR(INTL_SDS011));
 	add_form_checkbox_sensor(Config_hpm_read, FPSTR(INTL_HPM));
 	add_form_checkbox_sensor(Config_sps30_read, FPSTR(INTL_SPS30));
@@ -1447,7 +1460,6 @@ static void webserver_config_send_body_get(String& page_content) {
 	add_form_checkbox_sensor(Config_htu21d_read, FPSTR(INTL_HTU21D));
 	add_form_checkbox_sensor(Config_bmx280_read, FPSTR(INTL_BMX280));
 	add_form_checkbox_sensor(Config_sht3x_read, FPSTR(INTL_SHT3X));
-	add_form_checkbox_sensor(Config_ds18b20_read, FPSTR(INTL_DS18B20));
 
 	// Paginate page after ~ 1500 Bytes
 	server.sendContent(page_content);
@@ -1462,17 +1474,16 @@ static void webserver_config_send_body_get(String& page_content) {
 	page_content += FPSTR(INTL_MORE_SENSORS);
 	page_content += FPSTR(WEB_B_BR);
 
+	add_form_checkbox_sensor(Config_ds18b20_read, FPSTR(INTL_DS18B20));
 	add_form_checkbox_sensor(Config_pms_read, FPSTR(INTL_PMS));
 	add_form_checkbox_sensor(Config_bmp_read, FPSTR(INTL_BMP180));
 	add_form_checkbox(Config_gps_read, FPSTR(INTL_NEO6M));
 
-	page_content += FPSTR(WEB_BR_LF_B);
-	page_content += F("APIs");
-	page_content += FPSTR(WEB_B_BR);
 	// Paginate page after ~ 1500 Bytes
 	server.sendContent(page_content);
+	page_content = tmpl(FPSTR(WEB_DIV_PANEL), String(4));
 
-	page_content = form_checkbox(Config_send2dusti, F("API Sensor.Community"), false);
+	page_content += form_checkbox(Config_send2dusti, F("API Sensor.Community"), false);
 	page_content += FPSTR(WEB_NBSP_NBSP_BRACE);
 	page_content += form_checkbox(Config_ssl_dusti, FPSTR(WEB_HTTPS), false);
 	page_content += FPSTR(WEB_BRACE_BR);
@@ -1520,6 +1531,7 @@ static void webserver_config_send_body_get(String& page_content) {
 	add_form_input(page_content, Config_pwd_influx, FPSTR(INTL_PASSWORD), LEN_CFG_PASSWORD-1);
 	add_form_input(page_content, Config_measurement_name_influx, F("Measurement"), LEN_MEASUREMENT_NAME_INFLUX-1);
 	page_content += FPSTR(TABLE_TAG_CLOSE_BR);
+	page_content += F("</div></div>");
 	page_content += form_submit(FPSTR(INTL_SAVE_AND_RESTART));
 	page_content += FPSTR(BR_TAG);
 	page_content += FPSTR(WEB_BR_FORM);

--- a/airrohr-firmware/html-content.h
+++ b/airrohr-firmware/html-content.h
@@ -44,14 +44,20 @@ const char WEB_PAGE_HEADER_HEAD[] PROGMEM = "<meta name='viewport' content='widt
 body{font-family:Arial;margin:0}\
 .content{margin:10px}\
 .r{text-align:right}\
-td{vertical-align:top;}\
-a{text-decoration:none;padding:10px;background:#3ba;color:white;display:block;width:auto;border-radius:5px;box-shadow:0px 2px 2px #3ba;}\
-.wifi{background:none;color:blue;padding:5px;display:inline;}\
-input[type='text']{width:100%;}\
-input[type='password']{width:100%;}\
-input[type='submit']{color:white;text-align:left;border-radius:5px;font-size:medium;background:#b33;box-shadow:0px 2px 2px #b33;padding:9px !important;width:100%;border-style:none;}\
-input[type='submit']:hover {background:#d44} \
-.s_green{padding:9px !important;width:100%;border-style:none;background:#3ba;color:white;text-align:left;}\
+td{vertical-align:top}\
+a{text-decoration:none;padding:10px;background:#3ba;color:#fff;display:block;width:auto;border-radius:5px;box-shadow:0 2px 2px #3ba}\
+.wifi{background:0 0;color:#00f;padding:5px;display:inline;border:0;box-shadow:none}\
+input[type=text]{width:100%}\
+input[type=password]{width:100%}\
+input[type=submit]{color:#fff;text-align:left;border-radius:5px;font-size:medium;background:#b33;box-shadow:0 2px 2px #b33;padding:9px!important;width:100%;border-style:none}\
+input[type=submit]:hover{background:#d44}\
+.s_green{padding:9px !important;width:100%;border-style:none;background:#3ba;color:#fff;text-align:left}\
+.tabs{display:flex;flex-direction:row;align-items:stretch;align-content:flex-end;justify-content:flex-start}\
+.tab{padding:10px 20px;display:inline-block;color:#333;margin:0 20px}\
+.panels{min-height:200px;overflow:hidden;padding:20px;border:2px solid #3ba;margin-bottom:1em;box-shadow:0 4px 4px #3ba}\
+.radio{display:none}.panel{display:none}\
+#four:checked~.panels>#panel4,#one:checked~.panels>#panel1,#three:checked~.panels>#panel3,#two:checked~.panels>#panel2{display:block}\
+#four:checked~.tabs>#tab4,#one:checked~.tabs>#tab1,#three:checked~.tabs>#tab3,#two:checked~.tabs>#tab2{background:#3ba;color:#fff}\
 </style>\
 </head><body>\
 <div style='min-height:129px;background-color:#3ba;margin-bottom:20px;box-shadow:0px 4px 6px #3ba'>\
@@ -63,6 +69,7 @@ const char WEB_PAGE_HEADER_BODY[] PROGMEM = "<h3 style='margin:0'>" INTL_PM_SENS
 </small></div><div class='content'><h4>" INTL_HOME " {n} {t}</h4>";
 
 const char BR_TAG[] PROGMEM = "<br/>";
+const char WEB_DIV_PANEL[] PROGMEM = "</div><div class='panel' id='panel{v}'>";
 const char TABLE_TAG_OPEN[] PROGMEM = "<table>";
 const char TABLE_TAG_CLOSE_BR[] PROGMEM = "</table>";
 const char EMPTY_ROW[] PROGMEM = "<tr><td colspan='3'>&nbsp;</td></tr>";

--- a/airrohr-firmware/intl_bg.h
+++ b/airrohr-firmware/intl_bg.h
@@ -69,7 +69,7 @@ const char INTL_RESTART_SENSOR[] PROGMEM = "Рестартиране на сен
 #define INTL_HOME "Начало"
 #define INTL_BACK_TO_HOME "Обратно към начало"
 const char INTL_CURRENT_DATA[] PROGMEM = "Текущи данни";
-const char INTL_DEVICE_STATUS[] PROGMEM = "Карам статус";
+const char INTL_DEVICE_STATUS[] PROGMEM = "Статус на устройството";
 #define INTL_ACTIVE_SENSORS_MAP "Карта на активните сензори (външен линк)"
 #define INTL_CONFIGURATION_DELETE "Изтриване на Конфигурацията"
 #define INTL_CONFIGURATION_REALLY_DELETE "Наистина ли искате да изтриете конфигурацията?"

--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -37,7 +37,7 @@ board_build.f_cpu = 160000000L
 ;   (like OneWire, LiquidCrystal_I2C and TinyGPSPlus)
 
 lib_deps_generic_external =
-  1@2.3.4 ; OneWire
+  1@2.3.5 ; OneWire
   576@1.1.4 ; LiquidCrystal_I2C
   Adafruit BMP085 Library@1.0.1
   Adafruit HTU21DF Library@1.0.2


### PR DESCRIPTION
When a scan fails it returns a negative error code, which
we treated as a very large number of networks and allocated
a huge chunk of memory. We can be more clever than that.