### PR TITLE
Avoid endless loop on BMX280 read

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -7,6 +7,7 @@ NRZ-2020-130-B2
 * Skip initialization of display's when not configured
 * Delay OneWire initialization until configured
 * Fix bulgarian translation error (Fixes #622)
+* Fix hang on BME/P280 measurement read
 
 NRZ-2020-130-B1
 * next beta version

--- a/airrohr-firmware/bmx280_i2c.cpp
+++ b/airrohr-firmware/bmx280_i2c.cpp
@@ -231,7 +231,8 @@ void BMX280::takeForcedMeasurement() {
   write8(BMX280_REGISTER_CONTROL, _measReg.get());
   // wait until measurement has been completed, otherwise we would read
   // the values from the last measurement
-  while (read8(BMX280_REGISTER_STATUS) & 0x08)
+  unsigned attempts = 15;
+  while (--attempts && (read8(BMX280_REGISTER_STATUS) & 0x08))
     delay(1);
 }
 

--- a/airrohr-firmware/dnms_i2c.h
+++ b/airrohr-firmware/dnms_i2c.h
@@ -28,15 +28,6 @@
 
 #include <Arduino.h>
 #include <Wire.h>
-/*
- * 
- * Attention: in Wire.h set BUFFER_LENGTH to 64 !!
- *
- * #define BUFFER_LENGTH 64
- * 
- */
-
-
 #define DNMS_I2C_ADDRESS                0x55
 #define DNMS_MAX_VERSION_LEN            18
 #define DNMS_WORD_SIZE                  2

--- a/airrohr-firmware/sps30_i2c.h
+++ b/airrohr-firmware/sps30_i2c.h
@@ -41,14 +41,6 @@
 
 #include <Arduino.h>
 #include <Wire.h>
-/*
- * 
- * Attention: in Wire.h set BUFFER_LENGTH to 64 !!
- *
- * #define BUFFER_LENGTH 64
- * 
- */
-
 
 #define SPS_I2C_ADDRESS 0x69
 #define SPS_MAX_SERIAL_LEN 32


### PR DESCRIPTION
When the sensor no longer responds (aka all reads return with
0xFF) then we have an endless loop here. abort here after 15ms
because no measurement should take longer than 10ms.