### PR TITLE
Use HTTPS for Sensor.Community and Madavi.de

### DIFF
--- a/airrohr-firmware/airrohr-cfg.h
+++ b/airrohr-firmware/airrohr-cfg.h
@@ -48,9 +48,7 @@ enum ConfigShapeId {
 	Config_temp_correction,
 	Config_gps_read,
 	Config_send2dusti,
-	Config_ssl_dusti,
 	Config_send2madavi,
-	Config_ssl_madavi,
 	Config_send2sensemap,
 	Config_send2fsapp,
 	Config_send2aircms,
@@ -110,9 +108,7 @@ const char CFG_KEY_DNMS_CORRECTION[] PROGMEM = "dnms_correction";
 const char CFG_KEY_TEMP_CORRECTION[] PROGMEM = "temp_correction";
 const char CFG_KEY_GPS_READ[] PROGMEM = "gps_read";
 const char CFG_KEY_SEND2DUSTI[] PROGMEM = "send2dusti";
-const char CFG_KEY_SSL_DUSTI[] PROGMEM = "ssl_dusti";
 const char CFG_KEY_SEND2MADAVI[] PROGMEM = "send2madavi";
-const char CFG_KEY_SSL_MADAVI[] PROGMEM = "ssl_madavi";
 const char CFG_KEY_SEND2SENSEMAP[] PROGMEM = "send2sensemap";
 const char CFG_KEY_SEND2FSAPP[] PROGMEM = "send2fsapp";
 const char CFG_KEY_SEND2AIRCMS[] PROGMEM = "send2aircms";
@@ -172,9 +168,7 @@ static constexpr ConfigShapeEntry configShape[] PROGMEM = {
 	{ Config_Type_String, sizeof(cfg::temp_correction)-1, FPSTR(CFG_KEY_TEMP_CORRECTION), cfg::temp_correction },
 	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_GPS_READ), &cfg::gps_read },
 	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2DUSTI), &cfg::send2dusti },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SSL_DUSTI), &cfg::ssl_dusti },
 	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2MADAVI), &cfg::send2madavi },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SSL_MADAVI), &cfg::ssl_madavi },
 	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2SENSEMAP), &cfg::send2sensemap },
 	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2FSAPP), &cfg::send2fsapp },
 	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2AIRCMS), &cfg::send2aircms },

--- a/airrohr-firmware/airrohr-cfg.h.py
+++ b/airrohr-firmware/airrohr-cfg.h.py
@@ -25,9 +25,7 @@ String		dnms_correction
 String		temp_correction
 Bool		gps_read
 Bool		send2dusti
-Bool		ssl_dusti
 Bool		send2madavi
-Bool		ssl_madavi
 Bool		send2sensemap
 Bool		send2fsapp
 Bool		send2aircms

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -193,8 +193,6 @@ namespace cfg {
 	bool display_device_info = DISPLAY_DEVICE_INFO;
 
 	// API settings
-	bool ssl_madavi = SSL_MADAVI;
-	bool ssl_dusti = SSL_SENSORCOMMUNITY;
 	char senseboxid[LEN_SENSEBOXID] = SENSEBOXID;
 
 	char host_influx[LEN_HOST_INFLUX];
@@ -725,15 +723,11 @@ static void createLoggerConfigs() {
 	auto new_session = []() { return nullptr; };
 #endif
 	if (cfg::send2dusti) {
-		loggerConfigs[LoggerSensorCommunity].destport = 80;
-		if (cfg::ssl_dusti) {
-			loggerConfigs[LoggerSensorCommunity].destport = 443;
-			loggerConfigs[LoggerSensorCommunity].session = new_session();
-		}
+		loggerConfigs[LoggerSensorCommunity].destport = PORT_SENSORCOMMUNITY;
+		loggerConfigs[LoggerSensorCommunity].session = new_session();
 	}
-	loggerConfigs[LoggerMadavi].destport = PORT_MADAVI;
-	if (cfg::send2madavi && cfg::ssl_madavi) {
-		loggerConfigs[LoggerMadavi].destport = 443;
+	if (cfg::send2madavi) {
+		loggerConfigs[LoggerMadavi].destport = PORT_MADAVI;
 		loggerConfigs[LoggerMadavi].session = new_session();
 	}
 	loggerConfigs[LoggerSensemap].destport = PORT_SENSEMAP;
@@ -1102,14 +1096,8 @@ static void webserver_config_send_body_get(String& page_content) {
 
 	page_content += tmpl(FPSTR(INTL_SEND_TO), F("APIs"));
 	page_content += FPSTR(BR_TAG);
-	page_content += form_checkbox(Config_send2dusti, FPSTR(WEB_SENSORCOMMUNITY), false);
-	page_content += FPSTR(WEB_NBSP_NBSP_BRACE);
-	page_content += form_checkbox(Config_ssl_dusti, FPSTR(WEB_HTTPS), false);
-	page_content += FPSTR(WEB_BRACE_BR);
-	page_content += form_checkbox(Config_send2madavi, FPSTR(WEB_MADAVI), false);
-	page_content += FPSTR(WEB_NBSP_NBSP_BRACE);
-	page_content += form_checkbox(Config_ssl_madavi, FPSTR(WEB_HTTPS), false);
-	page_content += FPSTR(WEB_BRACE_BR);
+	add_form_checkbox(Config_send2dusti, FPSTR(WEB_SENSORCOMMUNITY));
+	add_form_checkbox(Config_send2madavi, FPSTR(WEB_MADAVI));
 	add_form_checkbox(Config_send2csv, FPSTR(WEB_CSV));
 	add_form_checkbox(Config_send2fsapp, FPSTR(WEB_FEINSTAUB_APP));
 	add_form_checkbox(Config_send2aircms, FPSTR(WEB_AIRCMS));

--- a/airrohr-firmware/ext_def.h
+++ b/airrohr-firmware/ext_def.h
@@ -14,13 +14,16 @@ const char WWW_PASSWORD[] PROGMEM = "";
 #define FS_SSID ""
 #define FS_PWD ""
 
-// Where to send the data?
+// Initial configuration on where to send sensor data: 1 is "send", 0 is "do not send"
+// https://sensor.community
 #define SEND2SENSORCOMMUNITY 1
-#define SSL_SENSORCOMMUNITY 0
+// https://www.madavi.de
 #define SEND2MADAVI 1
-#define SSL_MADAVI 0
+// https://opensensemap.org
 #define SEND2SENSEMAP 0
+// https://chillibits.com/pmapp/
 #define SEND2FSAPP 0
+// https://aircms.online
 #define SEND2AIRCMS 0
 #define SEND2MQTT 0
 #define SEND2INFLUX 0
@@ -55,11 +58,11 @@ struct LoggerConfig {
 // IMPORTANT: NO MORE CHANGES TO VARIABLE NAMES NEEDED FOR EXTERNAL APIS
 static const char HOST_MADAVI[] PROGMEM = "api-rrd.madavi.de";
 static const char URL_MADAVI[] PROGMEM = "/data.php";
-#define PORT_MADAVI 80
+#define PORT_MADAVI 443
 
 static const char HOST_SENSORCOMMUNITY[] PROGMEM = "api.sensor.community";
 static const char URL_SENSORCOMMUNITY[] PROGMEM = "/v1/push-sensor-data/";
-#define PORT_SENSORCOMMUNITY 80
+#define PORT_SENSORCOMMUNITY 443
 
 static const char HOST_SENSEMAP[] PROGMEM = "ingress.opensensemap.org";
 static const char URL_SENSEMAP[] PROGMEM = "/boxes/{v}/data?luftdaten=1";


### PR DESCRIPTION
Both of these services are enabled by default, thus it is important to use a secure HTTPS method of sending the data.