### PR TITLE
Fixed bug in fetchSensorBMX280

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -2699,7 +2699,7 @@ static void fetchSensorBMX280(String& s) {
 	const auto t = bmx280.readTemperature();
 	const auto p = bmx280.readPressure();
 	const auto h = bmx280.readHumidity();
-	if (isnan(t) || isnan(p)) {
+	if (isnan(t) || isnan(p) || isnan(h)) {
 		last_value_BMX280_T = -128.0;
 		last_value_BMX280_P = -1.0;
 		last_value_BME280_H = -1.0;


### PR DESCRIPTION
The issue occurs if when sensor returns NaN for humidity. This value was
handled correctly for temperature and pressure, but not for humidity.

See also #731 