### PR TITLE
Switch to HTTP for the fsapp endpoint

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -741,7 +741,6 @@ static void createLoggerConfigs() {
 	loggerConfigs[LoggerSensemap].destport = PORT_SENSEMAP;
 	loggerConfigs[LoggerSensemap].session = new_session();
 	loggerConfigs[LoggerFSapp].destport = PORT_FSAPP;
-	loggerConfigs[LoggerFSapp].session = new_session();
 	loggerConfigs[Loggeraircms].destport = PORT_AIRCMS;
 	loggerConfigs[LoggerInflux].destport = cfg::port_influx;
 	if (cfg::send2influx && cfg::ssl_influx) {

--- a/airrohr-firmware/ext_def.h
+++ b/airrohr-firmware/ext_def.h
@@ -65,9 +65,9 @@ static const char HOST_SENSEMAP[] PROGMEM = "ingress.opensensemap.org";
 static const char URL_SENSEMAP[] PROGMEM = "/boxes/{v}/data?luftdaten=1";
 #define PORT_SENSEMAP 443
 
-static const char HOST_FSAPP[] PROGMEM = "h2801469.stratoserver.net";
+static const char HOST_FSAPP[] PROGMEM = "server.chillibits.com";
 static const char URL_FSAPP[] PROGMEM = "/data.php";
-#define PORT_FSAPP 443
+#define PORT_FSAPP 80
 
 static const char HOST_AIRCMS[] PROGMEM = "doiot.ru";
 static const char URL_AIRCMS[] PROGMEM = "/php/sensors.php?h=";


### PR DESCRIPTION
Hi,
we're also slowly getting trouble with the server workload due to https encryption, so it would be better to downgrade to HTTP.
Spoiler: We currently work on a new high-performance API, which will be hopefully introduced in the near future.

Are there more changes required than changing the port to 80?