### PR TITLE
Add favicon to internal web page.

### DIFF
--- a/airrohr-firmware/html-content.h
+++ b/airrohr-firmware/html-content.h
@@ -66,6 +66,7 @@ input[type=submit]:hover{background:#d44}\
 
 const char WEB_PAGE_HEADER_HEAD[] PROGMEM = "<meta name='viewport' content='width=device-width'/>\
 <link rel='stylesheet' href='" STATIC_PREFIX "?r=css'>\
+<link rel='icon' type='image/png' href='" STATIC_PREFIX "?r=logo'/>\
 </style>\
 </head><body>\
 <div class='canvas'>\


### PR DESCRIPTION
This adds the built-in logo as a favicon to the internal web page.

By adding a favicon, the tab shows a little logo. Also any bookmarks will show the logo.
Tested with google chromium (Debian Linux)