### PR TITLE
Avoid promotion to double

### DIFF
--- a/airrohr-firmware/utils.cpp
+++ b/airrohr-firmware/utils.cpp
@@ -241,7 +241,7 @@ float readCorrectionOffset(const char* correction) {
 	// Avoiding atof() here as this adds a lot (~ 9kb) of code size
 	float r = float(strtol(correction, &pEnd, 10));
 	if (pEnd && pEnd[0] == '.' && pEnd[1] >= '0' && pEnd[1] <= '9') {
-		r += (r >= 0 ? 1.0 : -1.0) * ((pEnd[1] - '0') / 10.0);
+		r += (r >= 0.0f ? 1.0f : -1.0f) * ((pEnd[1] - '0') / 10.0f);
 	}
 	return r;
 }


### PR DESCRIPTION
The esp8266 isn't very efficient at handling double vars, and
we don't need it here. set every value literal to float type
to avoid an implicit promotion to double by the compiler.