### PR TITLE
Update to Arduino Core 2.7.4 (Fixes #753)

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -6,6 +6,7 @@ NRZ-2020-130-B6
 * Disabled IPv6 for stable release
 * Force I2C clock to 100k for better compatibility with sensors (Fixes #735)
 * Update ArduinoJson to 6.16.1
+* Update ArduinoCore to 2.7.4 to fix WPA downgrade issue (CVE-2020-12638)
 
 NRZ-2020-130-B5
 * Slovak translations added

--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,12 +1,17 @@
-NRZ-2020-130-B6
-* show new ID
-* rebranding to Sensor.Community
-* Tera Sensor Next PM sensor added (disabled from build atm)
+NRZ-2020-130-B7
+* Disabled Tera Sensor Next PM from build until conflicts with other sensors
+  can be resolved
 * Fix crash on enabling OLEDs (Fixes #671)
 * Disabled IPv6 for stable release
 * Force I2C clock to 100k for better compatibility with sensors (Fixes #735)
 * Update ArduinoJson to 6.16.1
 * Update ArduinoCore to 2.7.4 to fix WPA downgrade issue (CVE-2020-12638)
+* Force I2C clock to 100k for better compatibility with sensors
+
+NRZ-2020-130-B6
+* show new ID
+* rebranding to Sensor.Community
+* Tera Sensor Next PM sensor added
 
 NRZ-2020-130-B5
 * Slovak translations added

--- a/airrohr-firmware/airrohr-cfg.h
+++ b/airrohr-firmware/airrohr-cfg.h
@@ -14,13 +14,14 @@ enum ConfigEntryType : unsigned short {
 struct ConfigShapeEntry {
 	enum ConfigEntryType cfg_type;
 	unsigned short cfg_len;
-	const __FlashStringHelper* cfg_key;
+	const char* _cfg_key;
 	union {
 		void* as_void;
 		bool* as_bool;
 		unsigned int* as_uint;
 		char* as_str;
 	} cfg_val;
+	const __FlashStringHelper* cfg_key() const { return FPSTR(_cfg_key); }
 };
 
 enum ConfigShapeId {
@@ -87,129 +88,129 @@ enum ConfigShapeId {
 	Config_measurement_name_influx,
 	Config_ssl_influx,
 };
-const char CFG_KEY_CURRENT_LANG[] PROGMEM = "current_lang";
-const char CFG_KEY_WLANSSID[] PROGMEM = "wlanssid";
-const char CFG_KEY_WLANPWD[] PROGMEM = "wlanpwd";
-const char CFG_KEY_WWW_USERNAME[] PROGMEM = "www_username";
-const char CFG_KEY_WWW_PASSWORD[] PROGMEM = "www_password";
-const char CFG_KEY_FS_SSID[] PROGMEM = "fs_ssid";
-const char CFG_KEY_FS_PWD[] PROGMEM = "fs_pwd";
-const char CFG_KEY_WWW_BASICAUTH_ENABLED[] PROGMEM = "www_basicauth_enabled";
-const char CFG_KEY_DHT_READ[] PROGMEM = "dht_read";
-const char CFG_KEY_HTU21D_READ[] PROGMEM = "htu21d_read";
-const char CFG_KEY_PPD_READ[] PROGMEM = "ppd_read";
-const char CFG_KEY_SDS_READ[] PROGMEM = "sds_read";
-const char CFG_KEY_PMS_READ[] PROGMEM = "pms_read";
-const char CFG_KEY_HPM_READ[] PROGMEM = "hpm_read";
-const char CFG_KEY_NPM_READ[] PROGMEM = "npm_read";
-const char CFG_KEY_SPS30_READ[] PROGMEM = "sps30_read";
-const char CFG_KEY_BMP_READ[] PROGMEM = "bmp_read";
-const char CFG_KEY_BMX280_READ[] PROGMEM = "bmx280_read";
-const char CFG_KEY_SHT3X_READ[] PROGMEM = "sht3x_read";
-const char CFG_KEY_DS18B20_READ[] PROGMEM = "ds18b20_read";
-const char CFG_KEY_DNMS_READ[] PROGMEM = "dnms_read";
-const char CFG_KEY_DNMS_CORRECTION[] PROGMEM = "dnms_correction";
-const char CFG_KEY_TEMP_CORRECTION[] PROGMEM = "temp_correction";
-const char CFG_KEY_GPS_READ[] PROGMEM = "gps_read";
-const char CFG_KEY_SEND2DUSTI[] PROGMEM = "send2dusti";
-const char CFG_KEY_SSL_DUSTI[] PROGMEM = "ssl_dusti";
-const char CFG_KEY_SEND2MADAVI[] PROGMEM = "send2madavi";
-const char CFG_KEY_SSL_MADAVI[] PROGMEM = "ssl_madavi";
-const char CFG_KEY_SEND2SENSEMAP[] PROGMEM = "send2sensemap";
-const char CFG_KEY_SEND2FSAPP[] PROGMEM = "send2fsapp";
-const char CFG_KEY_SEND2AIRCMS[] PROGMEM = "send2aircms";
-const char CFG_KEY_SEND2CSV[] PROGMEM = "send2csv";
-const char CFG_KEY_AUTO_UPDATE[] PROGMEM = "auto_update";
-const char CFG_KEY_USE_BETA[] PROGMEM = "use_beta";
-const char CFG_KEY_HAS_DISPLAY[] PROGMEM = "has_display";
-const char CFG_KEY_HAS_SH1106[] PROGMEM = "has_sh1106";
-const char CFG_KEY_HAS_FLIPPED_DISPLAY[] PROGMEM = "has_flipped_display";
-const char CFG_KEY_HAS_LCD1602[] PROGMEM = "has_lcd1602";
-const char CFG_KEY_HAS_LCD1602_27[] PROGMEM = "has_lcd1602_27";
-const char CFG_KEY_HAS_LCD2004[] PROGMEM = "has_lcd2004";
-const char CFG_KEY_HAS_LCD2004_27[] PROGMEM = "has_lcd2004_27";
-const char CFG_KEY_DISPLAY_WIFI_INFO[] PROGMEM = "display_wifi_info";
-const char CFG_KEY_DISPLAY_DEVICE_INFO[] PROGMEM = "display_device_info";
-const char CFG_KEY_DEBUG[] PROGMEM = "debug";
-const char CFG_KEY_SENDING_INTERVALL_MS[] PROGMEM = "sending_intervall_ms";
-const char CFG_KEY_TIME_FOR_WIFI_CONFIG[] PROGMEM = "time_for_wifi_config";
-const char CFG_KEY_SENSEBOXID[] PROGMEM = "senseboxid";
-const char CFG_KEY_SEND2CUSTOM[] PROGMEM = "send2custom";
-const char CFG_KEY_HOST_CUSTOM[] PROGMEM = "host_custom";
-const char CFG_KEY_URL_CUSTOM[] PROGMEM = "url_custom";
-const char CFG_KEY_PORT_CUSTOM[] PROGMEM = "port_custom";
-const char CFG_KEY_USER_CUSTOM[] PROGMEM = "user_custom";
-const char CFG_KEY_PWD_CUSTOM[] PROGMEM = "pwd_custom";
-const char CFG_KEY_SSL_CUSTOM[] PROGMEM = "ssl_custom";
-const char CFG_KEY_SEND2INFLUX[] PROGMEM = "send2influx";
-const char CFG_KEY_HOST_INFLUX[] PROGMEM = "host_influx";
-const char CFG_KEY_URL_INFLUX[] PROGMEM = "url_influx";
-const char CFG_KEY_PORT_INFLUX[] PROGMEM = "port_influx";
-const char CFG_KEY_USER_INFLUX[] PROGMEM = "user_influx";
-const char CFG_KEY_PWD_INFLUX[] PROGMEM = "pwd_influx";
-const char CFG_KEY_MEASUREMENT_NAME_INFLUX[] PROGMEM = "measurement_name_influx";
-const char CFG_KEY_SSL_INFLUX[] PROGMEM = "ssl_influx";
+static constexpr char CFG_KEY_CURRENT_LANG[] PROGMEM = "current_lang";
+static constexpr char CFG_KEY_WLANSSID[] PROGMEM = "wlanssid";
+static constexpr char CFG_KEY_WLANPWD[] PROGMEM = "wlanpwd";
+static constexpr char CFG_KEY_WWW_USERNAME[] PROGMEM = "www_username";
+static constexpr char CFG_KEY_WWW_PASSWORD[] PROGMEM = "www_password";
+static constexpr char CFG_KEY_FS_SSID[] PROGMEM = "fs_ssid";
+static constexpr char CFG_KEY_FS_PWD[] PROGMEM = "fs_pwd";
+static constexpr char CFG_KEY_WWW_BASICAUTH_ENABLED[] PROGMEM = "www_basicauth_enabled";
+static constexpr char CFG_KEY_DHT_READ[] PROGMEM = "dht_read";
+static constexpr char CFG_KEY_HTU21D_READ[] PROGMEM = "htu21d_read";
+static constexpr char CFG_KEY_PPD_READ[] PROGMEM = "ppd_read";
+static constexpr char CFG_KEY_SDS_READ[] PROGMEM = "sds_read";
+static constexpr char CFG_KEY_PMS_READ[] PROGMEM = "pms_read";
+static constexpr char CFG_KEY_HPM_READ[] PROGMEM = "hpm_read";
+static constexpr char CFG_KEY_NPM_READ[] PROGMEM = "npm_read";
+static constexpr char CFG_KEY_SPS30_READ[] PROGMEM = "sps30_read";
+static constexpr char CFG_KEY_BMP_READ[] PROGMEM = "bmp_read";
+static constexpr char CFG_KEY_BMX280_READ[] PROGMEM = "bmx280_read";
+static constexpr char CFG_KEY_SHT3X_READ[] PROGMEM = "sht3x_read";
+static constexpr char CFG_KEY_DS18B20_READ[] PROGMEM = "ds18b20_read";
+static constexpr char CFG_KEY_DNMS_READ[] PROGMEM = "dnms_read";
+static constexpr char CFG_KEY_DNMS_CORRECTION[] PROGMEM = "dnms_correction";
+static constexpr char CFG_KEY_TEMP_CORRECTION[] PROGMEM = "temp_correction";
+static constexpr char CFG_KEY_GPS_READ[] PROGMEM = "gps_read";
+static constexpr char CFG_KEY_SEND2DUSTI[] PROGMEM = "send2dusti";
+static constexpr char CFG_KEY_SSL_DUSTI[] PROGMEM = "ssl_dusti";
+static constexpr char CFG_KEY_SEND2MADAVI[] PROGMEM = "send2madavi";
+static constexpr char CFG_KEY_SSL_MADAVI[] PROGMEM = "ssl_madavi";
+static constexpr char CFG_KEY_SEND2SENSEMAP[] PROGMEM = "send2sensemap";
+static constexpr char CFG_KEY_SEND2FSAPP[] PROGMEM = "send2fsapp";
+static constexpr char CFG_KEY_SEND2AIRCMS[] PROGMEM = "send2aircms";
+static constexpr char CFG_KEY_SEND2CSV[] PROGMEM = "send2csv";
+static constexpr char CFG_KEY_AUTO_UPDATE[] PROGMEM = "auto_update";
+static constexpr char CFG_KEY_USE_BETA[] PROGMEM = "use_beta";
+static constexpr char CFG_KEY_HAS_DISPLAY[] PROGMEM = "has_display";
+static constexpr char CFG_KEY_HAS_SH1106[] PROGMEM = "has_sh1106";
+static constexpr char CFG_KEY_HAS_FLIPPED_DISPLAY[] PROGMEM = "has_flipped_display";
+static constexpr char CFG_KEY_HAS_LCD1602[] PROGMEM = "has_lcd1602";
+static constexpr char CFG_KEY_HAS_LCD1602_27[] PROGMEM = "has_lcd1602_27";
+static constexpr char CFG_KEY_HAS_LCD2004[] PROGMEM = "has_lcd2004";
+static constexpr char CFG_KEY_HAS_LCD2004_27[] PROGMEM = "has_lcd2004_27";
+static constexpr char CFG_KEY_DISPLAY_WIFI_INFO[] PROGMEM = "display_wifi_info";
+static constexpr char CFG_KEY_DISPLAY_DEVICE_INFO[] PROGMEM = "display_device_info";
+static constexpr char CFG_KEY_DEBUG[] PROGMEM = "debug";
+static constexpr char CFG_KEY_SENDING_INTERVALL_MS[] PROGMEM = "sending_intervall_ms";
+static constexpr char CFG_KEY_TIME_FOR_WIFI_CONFIG[] PROGMEM = "time_for_wifi_config";
+static constexpr char CFG_KEY_SENSEBOXID[] PROGMEM = "senseboxid";
+static constexpr char CFG_KEY_SEND2CUSTOM[] PROGMEM = "send2custom";
+static constexpr char CFG_KEY_HOST_CUSTOM[] PROGMEM = "host_custom";
+static constexpr char CFG_KEY_URL_CUSTOM[] PROGMEM = "url_custom";
+static constexpr char CFG_KEY_PORT_CUSTOM[] PROGMEM = "port_custom";
+static constexpr char CFG_KEY_USER_CUSTOM[] PROGMEM = "user_custom";
+static constexpr char CFG_KEY_PWD_CUSTOM[] PROGMEM = "pwd_custom";
+static constexpr char CFG_KEY_SSL_CUSTOM[] PROGMEM = "ssl_custom";
+static constexpr char CFG_KEY_SEND2INFLUX[] PROGMEM = "send2influx";
+static constexpr char CFG_KEY_HOST_INFLUX[] PROGMEM = "host_influx";
+static constexpr char CFG_KEY_URL_INFLUX[] PROGMEM = "url_influx";
+static constexpr char CFG_KEY_PORT_INFLUX[] PROGMEM = "port_influx";
+static constexpr char CFG_KEY_USER_INFLUX[] PROGMEM = "user_influx";
+static constexpr char CFG_KEY_PWD_INFLUX[] PROGMEM = "pwd_influx";
+static constexpr char CFG_KEY_MEASUREMENT_NAME_INFLUX[] PROGMEM = "measurement_name_influx";
+static constexpr char CFG_KEY_SSL_INFLUX[] PROGMEM = "ssl_influx";
 static constexpr ConfigShapeEntry configShape[] PROGMEM = {
-	{ Config_Type_String, sizeof(cfg::current_lang)-1, FPSTR(CFG_KEY_CURRENT_LANG), cfg::current_lang },
-	{ Config_Type_String, sizeof(cfg::wlanssid)-1, FPSTR(CFG_KEY_WLANSSID), cfg::wlanssid },
-	{ Config_Type_Password, sizeof(cfg::wlanpwd)-1, FPSTR(CFG_KEY_WLANPWD), cfg::wlanpwd },
-	{ Config_Type_String, sizeof(cfg::www_username)-1, FPSTR(CFG_KEY_WWW_USERNAME), cfg::www_username },
-	{ Config_Type_Password, sizeof(cfg::www_password)-1, FPSTR(CFG_KEY_WWW_PASSWORD), cfg::www_password },
-	{ Config_Type_String, sizeof(cfg::fs_ssid)-1, FPSTR(CFG_KEY_FS_SSID), cfg::fs_ssid },
-	{ Config_Type_Password, sizeof(cfg::fs_pwd)-1, FPSTR(CFG_KEY_FS_PWD), cfg::fs_pwd },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_WWW_BASICAUTH_ENABLED), &cfg::www_basicauth_enabled },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_DHT_READ), &cfg::dht_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_HTU21D_READ), &cfg::htu21d_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_PPD_READ), &cfg::ppd_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SDS_READ), &cfg::sds_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_PMS_READ), &cfg::pms_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_HPM_READ), &cfg::hpm_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_NPM_READ), &cfg::npm_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SPS30_READ), &cfg::sps30_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_BMP_READ), &cfg::bmp_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_BMX280_READ), &cfg::bmx280_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SHT3X_READ), &cfg::sht3x_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_DS18B20_READ), &cfg::ds18b20_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_DNMS_READ), &cfg::dnms_read },
-	{ Config_Type_String, sizeof(cfg::dnms_correction)-1, FPSTR(CFG_KEY_DNMS_CORRECTION), cfg::dnms_correction },
-	{ Config_Type_String, sizeof(cfg::temp_correction)-1, FPSTR(CFG_KEY_TEMP_CORRECTION), cfg::temp_correction },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_GPS_READ), &cfg::gps_read },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2DUSTI), &cfg::send2dusti },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SSL_DUSTI), &cfg::ssl_dusti },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2MADAVI), &cfg::send2madavi },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SSL_MADAVI), &cfg::ssl_madavi },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2SENSEMAP), &cfg::send2sensemap },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2FSAPP), &cfg::send2fsapp },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2AIRCMS), &cfg::send2aircms },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2CSV), &cfg::send2csv },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_AUTO_UPDATE), &cfg::auto_update },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_USE_BETA), &cfg::use_beta },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_HAS_DISPLAY), &cfg::has_display },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_HAS_SH1106), &cfg::has_sh1106 },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_HAS_FLIPPED_DISPLAY), &cfg::has_flipped_display },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_HAS_LCD1602), &cfg::has_lcd1602 },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_HAS_LCD1602_27), &cfg::has_lcd1602_27 },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_HAS_LCD2004), &cfg::has_lcd2004 },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_HAS_LCD2004_27), &cfg::has_lcd2004_27 },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_DISPLAY_WIFI_INFO), &cfg::display_wifi_info },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_DISPLAY_DEVICE_INFO), &cfg::display_device_info },
-	{ Config_Type_UInt, 0, FPSTR(CFG_KEY_DEBUG), &cfg::debug },
-	{ Config_Type_Time, 0, FPSTR(CFG_KEY_SENDING_INTERVALL_MS), &cfg::sending_intervall_ms },
-	{ Config_Type_Time, 0, FPSTR(CFG_KEY_TIME_FOR_WIFI_CONFIG), &cfg::time_for_wifi_config },
-	{ Config_Type_String, sizeof(cfg::senseboxid)-1, FPSTR(CFG_KEY_SENSEBOXID), cfg::senseboxid },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2CUSTOM), &cfg::send2custom },
-	{ Config_Type_String, sizeof(cfg::host_custom)-1, FPSTR(CFG_KEY_HOST_CUSTOM), cfg::host_custom },
-	{ Config_Type_String, sizeof(cfg::url_custom)-1, FPSTR(CFG_KEY_URL_CUSTOM), cfg::url_custom },
-	{ Config_Type_UInt, 0, FPSTR(CFG_KEY_PORT_CUSTOM), &cfg::port_custom },
-	{ Config_Type_String, sizeof(cfg::user_custom)-1, FPSTR(CFG_KEY_USER_CUSTOM), cfg::user_custom },
-	{ Config_Type_Password, sizeof(cfg::pwd_custom)-1, FPSTR(CFG_KEY_PWD_CUSTOM), cfg::pwd_custom },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SSL_CUSTOM), &cfg::ssl_custom },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SEND2INFLUX), &cfg::send2influx },
-	{ Config_Type_String, sizeof(cfg::host_influx)-1, FPSTR(CFG_KEY_HOST_INFLUX), cfg::host_influx },
-	{ Config_Type_String, sizeof(cfg::url_influx)-1, FPSTR(CFG_KEY_URL_INFLUX), cfg::url_influx },
-	{ Config_Type_UInt, 0, FPSTR(CFG_KEY_PORT_INFLUX), &cfg::port_influx },
-	{ Config_Type_String, sizeof(cfg::user_influx)-1, FPSTR(CFG_KEY_USER_INFLUX), cfg::user_influx },
-	{ Config_Type_Password, sizeof(cfg::pwd_influx)-1, FPSTR(CFG_KEY_PWD_INFLUX), cfg::pwd_influx },
-	{ Config_Type_String, sizeof(cfg::measurement_name_influx)-1, FPSTR(CFG_KEY_MEASUREMENT_NAME_INFLUX), cfg::measurement_name_influx },
-	{ Config_Type_Bool, 0, FPSTR(CFG_KEY_SSL_INFLUX), &cfg::ssl_influx },
+	{ Config_Type_String, sizeof(cfg::current_lang)-1, CFG_KEY_CURRENT_LANG, cfg::current_lang },
+	{ Config_Type_String, sizeof(cfg::wlanssid)-1, CFG_KEY_WLANSSID, cfg::wlanssid },
+	{ Config_Type_Password, sizeof(cfg::wlanpwd)-1, CFG_KEY_WLANPWD, cfg::wlanpwd },
+	{ Config_Type_String, sizeof(cfg::www_username)-1, CFG_KEY_WWW_USERNAME, cfg::www_username },
+	{ Config_Type_Password, sizeof(cfg::www_password)-1, CFG_KEY_WWW_PASSWORD, cfg::www_password },
+	{ Config_Type_String, sizeof(cfg::fs_ssid)-1, CFG_KEY_FS_SSID, cfg::fs_ssid },
+	{ Config_Type_Password, sizeof(cfg::fs_pwd)-1, CFG_KEY_FS_PWD, cfg::fs_pwd },
+	{ Config_Type_Bool, 0, CFG_KEY_WWW_BASICAUTH_ENABLED, &cfg::www_basicauth_enabled },
+	{ Config_Type_Bool, 0, CFG_KEY_DHT_READ, &cfg::dht_read },
+	{ Config_Type_Bool, 0, CFG_KEY_HTU21D_READ, &cfg::htu21d_read },
+	{ Config_Type_Bool, 0, CFG_KEY_PPD_READ, &cfg::ppd_read },
+	{ Config_Type_Bool, 0, CFG_KEY_SDS_READ, &cfg::sds_read },
+	{ Config_Type_Bool, 0, CFG_KEY_PMS_READ, &cfg::pms_read },
+	{ Config_Type_Bool, 0, CFG_KEY_HPM_READ, &cfg::hpm_read },
+	{ Config_Type_Bool, 0, CFG_KEY_NPM_READ, &cfg::npm_read },
+	{ Config_Type_Bool, 0, CFG_KEY_SPS30_READ, &cfg::sps30_read },
+	{ Config_Type_Bool, 0, CFG_KEY_BMP_READ, &cfg::bmp_read },
+	{ Config_Type_Bool, 0, CFG_KEY_BMX280_READ, &cfg::bmx280_read },
+	{ Config_Type_Bool, 0, CFG_KEY_SHT3X_READ, &cfg::sht3x_read },
+	{ Config_Type_Bool, 0, CFG_KEY_DS18B20_READ, &cfg::ds18b20_read },
+	{ Config_Type_Bool, 0, CFG_KEY_DNMS_READ, &cfg::dnms_read },
+	{ Config_Type_String, sizeof(cfg::dnms_correction)-1, CFG_KEY_DNMS_CORRECTION, cfg::dnms_correction },
+	{ Config_Type_String, sizeof(cfg::temp_correction)-1, CFG_KEY_TEMP_CORRECTION, cfg::temp_correction },
+	{ Config_Type_Bool, 0, CFG_KEY_GPS_READ, &cfg::gps_read },
+	{ Config_Type_Bool, 0, CFG_KEY_SEND2DUSTI, &cfg::send2dusti },
+	{ Config_Type_Bool, 0, CFG_KEY_SSL_DUSTI, &cfg::ssl_dusti },
+	{ Config_Type_Bool, 0, CFG_KEY_SEND2MADAVI, &cfg::send2madavi },
+	{ Config_Type_Bool, 0, CFG_KEY_SSL_MADAVI, &cfg::ssl_madavi },
+	{ Config_Type_Bool, 0, CFG_KEY_SEND2SENSEMAP, &cfg::send2sensemap },
+	{ Config_Type_Bool, 0, CFG_KEY_SEND2FSAPP, &cfg::send2fsapp },
+	{ Config_Type_Bool, 0, CFG_KEY_SEND2AIRCMS, &cfg::send2aircms },
+	{ Config_Type_Bool, 0, CFG_KEY_SEND2CSV, &cfg::send2csv },
+	{ Config_Type_Bool, 0, CFG_KEY_AUTO_UPDATE, &cfg::auto_update },
+	{ Config_Type_Bool, 0, CFG_KEY_USE_BETA, &cfg::use_beta },
+	{ Config_Type_Bool, 0, CFG_KEY_HAS_DISPLAY, &cfg::has_display },
+	{ Config_Type_Bool, 0, CFG_KEY_HAS_SH1106, &cfg::has_sh1106 },
+	{ Config_Type_Bool, 0, CFG_KEY_HAS_FLIPPED_DISPLAY, &cfg::has_flipped_display },
+	{ Config_Type_Bool, 0, CFG_KEY_HAS_LCD1602, &cfg::has_lcd1602 },
+	{ Config_Type_Bool, 0, CFG_KEY_HAS_LCD1602_27, &cfg::has_lcd1602_27 },
+	{ Config_Type_Bool, 0, CFG_KEY_HAS_LCD2004, &cfg::has_lcd2004 },
+	{ Config_Type_Bool, 0, CFG_KEY_HAS_LCD2004_27, &cfg::has_lcd2004_27 },
+	{ Config_Type_Bool, 0, CFG_KEY_DISPLAY_WIFI_INFO, &cfg::display_wifi_info },
+	{ Config_Type_Bool, 0, CFG_KEY_DISPLAY_DEVICE_INFO, &cfg::display_device_info },
+	{ Config_Type_UInt, 0, CFG_KEY_DEBUG, &cfg::debug },
+	{ Config_Type_Time, 0, CFG_KEY_SENDING_INTERVALL_MS, &cfg::sending_intervall_ms },
+	{ Config_Type_Time, 0, CFG_KEY_TIME_FOR_WIFI_CONFIG, &cfg::time_for_wifi_config },
+	{ Config_Type_String, sizeof(cfg::senseboxid)-1, CFG_KEY_SENSEBOXID, cfg::senseboxid },
+	{ Config_Type_Bool, 0, CFG_KEY_SEND2CUSTOM, &cfg::send2custom },
+	{ Config_Type_String, sizeof(cfg::host_custom)-1, CFG_KEY_HOST_CUSTOM, cfg::host_custom },
+	{ Config_Type_String, sizeof(cfg::url_custom)-1, CFG_KEY_URL_CUSTOM, cfg::url_custom },
+	{ Config_Type_UInt, 0, CFG_KEY_PORT_CUSTOM, &cfg::port_custom },
+	{ Config_Type_String, sizeof(cfg::user_custom)-1, CFG_KEY_USER_CUSTOM, cfg::user_custom },
+	{ Config_Type_Password, sizeof(cfg::pwd_custom)-1, CFG_KEY_PWD_CUSTOM, cfg::pwd_custom },
+	{ Config_Type_Bool, 0, CFG_KEY_SSL_CUSTOM, &cfg::ssl_custom },
+	{ Config_Type_Bool, 0, CFG_KEY_SEND2INFLUX, &cfg::send2influx },
+	{ Config_Type_String, sizeof(cfg::host_influx)-1, CFG_KEY_HOST_INFLUX, cfg::host_influx },
+	{ Config_Type_String, sizeof(cfg::url_influx)-1, CFG_KEY_URL_INFLUX, cfg::url_influx },
+	{ Config_Type_UInt, 0, CFG_KEY_PORT_INFLUX, &cfg::port_influx },
+	{ Config_Type_String, sizeof(cfg::user_influx)-1, CFG_KEY_USER_INFLUX, cfg::user_influx },
+	{ Config_Type_Password, sizeof(cfg::pwd_influx)-1, CFG_KEY_PWD_INFLUX, cfg::pwd_influx },
+	{ Config_Type_String, sizeof(cfg::measurement_name_influx)-1, CFG_KEY_MEASUREMENT_NAME_INFLUX, cfg::measurement_name_influx },
+	{ Config_Type_Bool, 0, CFG_KEY_SSL_INFLUX, &cfg::ssl_influx },
 };

--- a/airrohr-firmware/airrohr-cfg.h.py
+++ b/airrohr-firmware/airrohr-cfg.h.py
@@ -82,13 +82,14 @@ enum ConfigEntryType : unsigned short {
 struct ConfigShapeEntry {
 	enum ConfigEntryType cfg_type;
 	unsigned short cfg_len;
-	const __FlashStringHelper* cfg_key;
+	const char* _cfg_key;
 	union {
 		void* as_void;
 		bool* as_bool;
 		unsigned int* as_uint;
 		char* as_str;
 	} cfg_val;
+	const __FlashStringHelper* cfg_key() const { return FPSTR(_cfg_key); }
 };
 
 enum ConfigShapeId {""", file=h)
@@ -99,7 +100,7 @@ enum ConfigShapeId {""", file=h)
 
     for cfgentry in configshape_in.strip().split('\n'):
         _, cfgkey = cfgentry.split()
-        print("const char CFG_KEY_", cfgkey.upper(),
+        print("static constexpr char CFG_KEY_", cfgkey.upper(),
               "[] PROGMEM = \"", cfgkey, "\";", sep='', file=h)
 
     print("static constexpr ConfigShapeEntry configShape[] PROGMEM = {",
@@ -108,7 +109,7 @@ enum ConfigShapeId {""", file=h)
         cfgtype, cfgkey = cfgentry.split()
         print("\t{ Config_Type_", cfgtype,
               ", sizeof(cfg::" + cfgkey + ")-1" if cfgtype in ('String', 'Password') else ", 0",
-              ", FPSTR(CFG_KEY_", cfgkey.upper(),
-              "), ", "" if cfgtype in ('String', 'Password') else "&",
+              ", CFG_KEY_", cfgkey.upper(),
+              ", ", "" if cfgtype in ('String', 'Password') else "&",
               "cfg::", cfgkey, " },", sep='', file=h)
     print("};", file=h)

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -608,6 +608,8 @@ static void readConfig(bool oldconfig = false) {
 		cfgName += F(".old");
 	}
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
 	File configFile = SPIFFS.open(cfgName, "r");
 	if (!configFile) {
 		if (!oldconfig) {
@@ -622,6 +624,7 @@ static void readConfig(bool oldconfig = false) {
 	DynamicJsonDocument json(JSON_BUFFER_SIZE);
 	DeserializationError err = deserializeJson(json, configFile.readString());
 	configFile.close();
+#pragma GCC diagnostic pop
 
 	if (!err) {
 		debug_outln_info(F("parsed json..."));
@@ -695,11 +698,17 @@ static void readConfig(bool oldconfig = false) {
 static void init_config() {
 
 	debug_outln_info(F("mounting FS..."));
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
+
 #if defined(ESP32)
 	bool spiffs_begin_ok = SPIFFS.begin(FORMAT_SPIFFS_IF_FAILED);
 #else
 	bool spiffs_begin_ok = SPIFFS.begin();
 #endif
+
+#pragma GCC diagnostic pop
 
 	if (!spiffs_begin_ok) {
 		debug_outln_error(F("failed to mount FS"));
@@ -734,6 +743,9 @@ static bool writeConfig() {
 		};
 	}
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
+
 	SPIFFS.remove(F("/config.json.old"));
 	SPIFFS.rename(F("/config.json"), F("/config.json.old"));
 
@@ -746,6 +758,8 @@ static bool writeConfig() {
 		debug_outln_error(F("failed to open config file for writing"));
 		return false;
 	}
+
+#pragma GCC diagnostic pop
 
 	return true;
 }
@@ -1279,7 +1293,14 @@ static void sensor_restart() {
 		WiFi.mode(WIFI_OFF);
 		delay(100);
 #endif
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
+
 		SPIFFS.end();
+
+#pragma GCC diagnostic pop
+
 		serialSDS.end();
 		debug_outln_info(F("Restart."));
 		delay(500);
@@ -1706,6 +1727,8 @@ static void webserver_removeConfig() {
 		page_content += FPSTR(WEB_REMOVE_CONFIG_CONTENT);
 
 	} else {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
 		// Silently remove the desaster backup
 		SPIFFS.remove(F("/config.json.old"));
 		if (SPIFFS.exists(F("/config.json"))) {	//file exists
@@ -1718,6 +1741,7 @@ static void webserver_removeConfig() {
 		} else {
 			page_content += F("<h3>" INTL_CONFIG_NOT_FOUND ".</h3>");
 		}
+#pragma GCC diagnostic pop
 	}
 	end_html_page(page_content);
 }
@@ -3314,7 +3338,7 @@ static bool fwDownloadStream(WiFiClientSecure& client, const String& url, Stream
 	}
 
 	http.setUserAgent(agent);
-    http.setReuse(false);
+	http.setReuse(false);
 
 	debug_outln_verbose(F("HTTP GET: "), String(FPSTR(FW_DOWNLOAD_HOST)) + ':' + String(FW_DOWNLOAD_PORT) + url);
 
@@ -3340,6 +3364,8 @@ static bool fwDownloadStreamFile(WiFiClientSecure& client, const String& url, co
 	fname_new += F(".new");
 	bool downloadSuccess = false;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
 	File fwFile = SPIFFS.open(fname_new, "w");
 	if (fwFile) {
 		downloadSuccess = fwDownloadStream(client, url, &fwFile);
@@ -3355,6 +3381,7 @@ static bool fwDownloadStreamFile(WiFiClientSecure& client, const String& url, co
 		return true;
 
 	SPIFFS.remove(fname_new);
+#pragma GCC diagnostic pop
 	return false;
 }
 
@@ -3417,6 +3444,9 @@ static void twoStageOTAUpdate() {
 	if (!fwDownloadStreamFile(client, FPSTR(FW_2ND_LOADER_URL), loader_name))
 		return;
 
+	// SPIFFS is deprecated, we know
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
 	File fwFile = SPIFFS.open(firmware_name, "r");
 	if (!fwFile) {
 		SPIFFS.remove(firmware_name);
@@ -3454,6 +3484,7 @@ static void twoStageOTAUpdate() {
 		SPIFFS.remove(firmware_md5);
 		return;
 	}
+#pragma GCC diagnostic pop
 
 	sensor_restart();
 #endif

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -60,7 +60,7 @@
 #include <pgmspace.h>
 
 // increment on change
-#define SOFTWARE_VERSION_STR "NRZ-2020-130-B6"
+#define SOFTWARE_VERSION_STR "NRZ-2020-130-B7"
 String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 /*****************************************************************

--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -25,7 +25,6 @@ build_flags =
   -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
   -D HTTPCLIENT_1_1_COMPATIBLE=0 -D NO_GLOBAL_SERIAL=0
   -DNDEBUG
-  -Wl,-Teagle.flash.4m3m.ld
 
 build_flags_esp32 =
   -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
@@ -33,6 +32,8 @@ build_flags_esp32 =
 build_flags_esp32_release = ${common.build_flags_esp32} -DNDEBUG
 build_flags_esp32_debug = ${common.build_flags_esp32} -g -Og -fno-inline -DUSING_JTAG_DEBUGGER_PINS=1 -DDEBUG_ESP_PORT=Serial
 
+board_build.ldscript = eagle.flash.4m3m.ld
+board_build.filesystem = spiffs
 board_build.f_cpu = 160000000L
 ; Always depend on specific library versions (wherever possible and only for external libraries)
 ; Keep Library names in the order of their dependencies (leaves at the top)
@@ -40,7 +41,7 @@ board_build.f_cpu = 160000000L
 ; Use library ID numbers instead of names for libraries whose names are not unique
 ;   (like OneWire, LiquidCrystal_I2C and TinyGPSPlus)
 
-lib_deps_generic_external =
+lib_deps_external =
   1@2.3.5 ; OneWire
   576@1.1.4 ; LiquidCrystal_I2C
   Adafruit BMP085 Library@1.0.1
@@ -75,8 +76,8 @@ lib_deps_esp32_platform =
   Update
   ESPmDNS
 
-lib_deps_esp8266 = ${common.lib_deps_esp8266_platform} ${common.lib_deps_generic_external}
-lib_deps_esp32 = ${common.lib_deps_esp32_platform} ${common.lib_deps_generic_external}
+lib_deps_esp8266 = ${common.lib_deps_esp8266_platform} ${common.lib_deps_external}
+lib_deps_esp32 = ${common.lib_deps_esp32_platform} ${common.lib_deps_external}
 
 extra_scripts = platformio_script.py
 # This release is reflecting the Arduino Core 2.6.2 release
@@ -119,6 +120,8 @@ check_tool = clangtidy
 check_flags =
   clangtidy: --checks=-*,cert-*,bugprone-*,clang-analyzer-*,hicpp-*,modernize-*,performance-*,portability-*,-readability-*
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_DE
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -129,6 +132,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_BG
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -139,6 +144,8 @@ framework = arduino
 platform = ${common.platform_version}
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_CZ
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -149,6 +156,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_DK
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -159,6 +168,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_EN
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -169,6 +180,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_ES
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -179,6 +192,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_FR
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -189,6 +204,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_HU
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -199,6 +216,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_IT
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -209,6 +228,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_LU
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -219,6 +240,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_NL
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -229,6 +252,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_PL
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -239,6 +264,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_PT
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -249,6 +276,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_RS
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -259,6 +288,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_RU
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -269,6 +300,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_SE
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -279,6 +312,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_SK
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -289,6 +324,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_TR
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
@@ -299,6 +336,8 @@ platform = ${common.platform_version}
 framework = arduino
 board = nodemcuv2
 board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
 build_flags = ${common.build_flags} -DINTL_UA
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}

--- a/airrohr-firmware/utils.cpp
+++ b/airrohr-firmware/utils.cpp
@@ -177,6 +177,9 @@ void configureCACertTrustAnchor(WiFiClientSecure* client) {
 
 bool launchUpdateLoader(const String& md5) {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored  "-Wdeprecated-declarations"
+
 	File loaderFile = SPIFFS.open(F("/loader.bin"), "r");
 	if (!loaderFile) {
 		return false;
@@ -202,6 +205,7 @@ bool launchUpdateLoader(const String& md5) {
 	debug_outln_info(F("Erasing SDK config."));
 	ESP.eraseConfig();
 	return true;
+#pragma GCC diagnostic pop
 }
 
 #endif

--- a/airrohr-firmware/utils.cpp
+++ b/airrohr-firmware/utils.cpp
@@ -534,20 +534,6 @@ void NPM_cmd(PmSensorCmd2 cmd) {
 	serialSDS.write(buf, cmd_len);
 }
 
-// workaround for https://github.com/plerup/espsoftwareserial/issues/127
-void yield_for_serial_buffer(size_t length) {
-	unsigned long startMillis = millis();
-	unsigned long yield_timeout = length * 9 * 1000 / 9600;
-
-	while (serialSDS.available() < (int) length &&
-				millis() - startMillis < yield_timeout) {
-		yield();
-#if defined(ESP8266)
-		serialSDS.perform_work();
-#endif
-	}
-}
-
 const __FlashStringHelper* loggerDescription(unsigned i) {
     const __FlashStringHelper* logger = nullptr;
     switch (i) {

--- a/airrohr-firmware/utils.h
+++ b/airrohr-firmware/utils.h
@@ -139,7 +139,6 @@ extern void debug_outln_info_bool(const __FlashStringHelper* text, const bool op
 
 
 extern bool SDS_checksum_valid(const uint8_t (&data)[8]);
-extern void yield_for_serial_buffer(size_t length);
 extern void SDS_rawcmd(const uint8_t cmd_head1, const uint8_t cmd_head2, const uint8_t cmd_head3);
 extern bool SDS_cmd(PmSensorCmd cmd);
 extern bool PMS_cmd(PmSensorCmd cmd);


### PR DESCRIPTION
This is a huge update, covering a much newer SoftwareSerial and
includes many fixes and optimisations. Unfortunately it deprecates
SPIFFS so we now have to live with compiler warnings until
we managed to find an upgrade path to littlefs.

Includes a fix for a WPA plain-text attack security issue so
we need to update, even though it increases FW quite a bit.