### PR TITLE
Update ArduinoJson 6.16.1

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -4,7 +4,8 @@ NRZ-2020-130-B6
 * Tera Sensor Next PM sensor added (disabled from build atm)
 * Fix crash on enabling OLEDs (Fixes #671)
 * Disabled IPv6 for stable release
-* Force I2C clock to 100k for better compatibility with sensors
+* Force I2C clock to 100k for better compatibility with sensors (Fixes #735)
+* Update ArduinoJson to 6.16.1
 
 NRZ-2020-130-B5
 * Slovak translations added

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -99,6 +99,9 @@ String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 #include <SSD1306.h>
 #include <SH1106.h>
 #include <LiquidCrystal_I2C.h>
+#define ARDUINOJSON_ENABLE_ARDUINO_STREAM 0
+#define ARDUINOJSON_ENABLE_ARDUINO_PRINT 0
+#define ARDUINOJSON_DECODE_UNICODE 0
 #include <ArduinoJson.h>
 #include <DNSServer.h>
 #include "./DHT.h"
@@ -618,7 +621,7 @@ static void readConfig(bool oldconfig = false) {
 
 	debug_outln_info(F("opened config file..."));
 	DynamicJsonDocument json(JSON_BUFFER_SIZE);
-	DeserializationError err = deserializeJson(json, configFile);
+	DeserializationError err = deserializeJson(json, configFile.readString());
 	configFile.close();
 
 	if (!err) {

--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -46,7 +46,7 @@ lib_deps_generic_external =
   Adafruit BMP085 Library@1.0.1
   Adafruit HTU21DF Library@1.0.2
   Adafruit SHT31 Library@1.1.6
-  ArduinoJson@6.13.0
+  ArduinoJson@6.16.1
   DallasTemperature@3.8.0
   ESP8266_SSD1306@4.1.0
   1655@1.0.2 ; TinyGPSPlus, formerly this was referenced as mikalhart/TinyGPSPlus#v0.95


### PR DESCRIPTION
This provides a couple of nice fixes and also reduces code size
footprint by ~ 0.5kb. Changelog in detail is:

* Added comparisons (>, >=, ==, !=, <, and <=) between JsonVariants
* Added string deduplication (issue #1303)
* Added JsonString::operator!=
* Set ARDUINOJSON_DECODE_UNICODE to 1 by default
* Fixed copyArray() not working with String, ElementProxy, and MemberProxy
* Fixed error getOrAddElement is not a member of ElementProxy (issue #1311)
* Fixed excessive stack usage when compiled with -Og (issues #1210 and #1314)
* Fixed Warning[Pa093]: implicit conversion from floating point to integer on IAR compiler (PR #1328 by @stawiski)
* Fixed deserializeJson() that stopped reading after {} (issue #1335)
* CMake: don't build tests when imported in another project
* CMake: made project arch-independent
* Visual Studio: fixed error C2766 with flag /Zc:__cplusplus (issue #1250)
* Added support for JsonDocument to copyArray() (issue #1255)
* Added support for enums in as<T>() and is<T>() (issue #1256)
* Added JsonVariant as an input type for deserializeXxx()
* For example, you can do: deserializeJson(doc2, doc1["payload"])
* Break the build if using 64-bit integers with ARDUINOJSON_USE_LONG_LONG==0a
* Fixed "maybe-uninitialized" warning (issue #1217)
* Fixed "statement is unreachable" warning on IAR (issue #1233)
* Fixed "pointless integer comparison" warning on IAR (issue #1233)
* Added CMake "install" target (issue #1209)
* Disabled alignment on AVR (issue #1231)
* Added DeserializationOption::Filter (issue #959)
* Added example JsonFilterExample.ino
* Changed the array subscript operator to automatically add missing elements
* Fixed "deprecated-copy" warning on GCC 9 (fixes #1184)
* Fixed MemberProxy::set(char[]) not duplicating the string (issue #1191)
* Fixed enums serialized as booleans (issue #1197)
* Fixed incorrect string comparison on some platforms (issue #1198)
* Added move-constructor and move-assignment to BasicJsonDocument
* Added BasicJsonDocument::garbageCollect() (issue #1195)
* Added StaticJsonDocument::garbageCollect()
* Changed copy-constructor of BasicJsonDocument to preserve the capacity of the source.
* Removed copy-constructor of JsonDocument (issue #1189)
* Fixed regression in UTF16 decoding (issue #1173)
* Fixed containsKey() on JsonVariantConst
* Added getElement() and getMember() to JsonVariantConst
* Added BasicJsonDocument::shrinkToFit()
* Added support of uint8_t for serializeJson(), serializeJsonPretty(), and serializeMsgPack() (issue #1142)
* Added ARDUINOJSON_ENABLE_COMMENTS to enable support for comments (defaults to 0)
* Auto enable support for std::string and std::stream on modern compilers (issue #1156)
* (No need to define ARDUINOJSON_ENABLE_STD_STRING and ARDUINOJSON_ENABLE_STD_STREAM anymore)
* Improved decoding of UTF-16 surrogate pairs (PR #1157 by @kaysievers)
* Added measureJson, measureJsonPretty, and measureMsgPack to keywords.txt
* Fixed variant.is<nullptr_t>()
* Fixed value returned by serializeJson(), serializeJsonPretty(), and serializeMsgPack() when writing to a String
* Improved speed of serializeJson(), serializeJsonPretty(), and serializeMsgPack() when writing to a String