### PR TITLE
Force I2C speed to 100k always

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -3,6 +3,7 @@ NRZ-2020-130-B6
 * rebranding to Sensor.Community
 * Tera Sensor Next PM sensor added (disabled from build atm)
 * Fix crash on enabling OLEDs (Fixes #671)
+* Force I2C clock to 100k for better compatibility with sensors
 
 NRZ-2020-130-B5
 * Slovak translations added

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -3808,6 +3808,12 @@ static void init_display() {
 		lcd_2004->init();
 		lcd_2004->backlight();
 	}
+
+	// reset back to 100k as the OLEDDisplay initialization is
+	// modifying the I2C speed to 400k, which overwhelms some of the
+	// sensors.
+	Wire.setClock(100000);
+	Wire.setClockStretchLimit(150000);
 }
 
 /*****************************************************************


### PR DESCRIPTION
The OLEDDisplay code is bumping I2C frequency to 400k, which
causes an issue with sensors that can't handle fast speed
(like SPS30 and probably others). reset it back to the old speed.
Downside is that actual display users will see slower update
times now.