### PR TITLE
Fixed for sending GPS_datetime Fixes #781

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -2229,9 +2229,18 @@ static void create_influxdb_string_from_data(String& data_4_influxdb, const Stri
 		data_4_influxdb += esp_chipid + " ";
 		for (JsonObject measurement : json2data[FPSTR(JSON_SENSOR_DATA_VALUES)].as<JsonArray>()) {
 			data_4_influxdb += measurement["value_type"].as<char*>();
-			data_4_influxdb += '=';
-			data_4_influxdb += measurement["value"].as<char*>();
-			data_4_influxdb += ',';
+			data_4_influxdb += "=";
+
+			if (isNumeric(measurement["value"])) {
+				//send numerics without quotes
+				data_4_influxdb += measurement["value"].as<char*>();
+			} else {
+				//quote string values
+				data_4_influxdb += "\"";
+				data_4_influxdb += measurement["value"].as<char*>();
+				data_4_influxdb += "\"";
+			}
+			data_4_influxdb += ",";
 		}
 		if ((unsigned)(data_4_influxdb.lastIndexOf(',') + 1) == data_4_influxdb.length()) {
 			data_4_influxdb.remove(data_4_influxdb.length() - 1);
@@ -3243,7 +3252,6 @@ static void fetchSensorDNMS(String& s) {
 	debug_outln_info(FPSTR(DBG_TXT_SEP));
 	debug_outln_verbose(FPSTR(DBG_TXT_END_READING), FPSTR(SENSORS_DNMS));
 }
-
 /*****************************************************************
  * read GPS sensor values                                        *
  *****************************************************************/
@@ -3302,7 +3310,7 @@ static void fetchSensorGPS(String& s) {
 		add_Value2Json(s, F("GPS_lat"), String(last_value_GPS_lat, 6));
 		add_Value2Json(s, F("GPS_lon"), String(last_value_GPS_lon, 6));
 		add_Value2Json(s, F("GPS_height"), F("Altitude: "), float(last_value_GPS_alt));
-		add_Value2Json(s, F("GPS_datetime"), "\"" + last_value_GPS_datetime + "\"");
+		add_Value2Json(s, F("GPS_timestamp"), last_value_GPS_datetime);
 		debug_outln_info(FPSTR(DBG_TXT_SEP));
 	}
 

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -3284,7 +3284,7 @@ static void fetchSensorGPS(String& s) {
 		}
 		if (gps.date.isValid() && gps.time.isValid()) {
 			char gps_datetime[37];
-			snprintf_P(gps_datetime, sizeof(gps_datetime), PSTR("%02d-%02d%04dT%02d:%02d:%02d.%02d"),
+			snprintf_P(gps_datetime, sizeof(gps_datetime), PSTR("%04d-%02d-%02dT%02d:%02d:%02d.%03d"),
 				gps.date.year(), gps.date.month(), gps.date.day(),gps.time.hour(), gps.time.minute(), gps.time.second(), gps.time.centisecond());
 			last_value_GPS_datetime = gps_datetime;
 		}

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -3287,6 +3287,9 @@ static void fetchSensorGPS(String& s) {
 			snprintf_P(gps_datetime, sizeof(gps_datetime), PSTR("%04d-%02d-%02dT%02d:%02d:%02d.%03d"),
 				gps.date.year(), gps.date.month(), gps.date.day(),gps.time.hour(), gps.time.minute(), gps.time.second(), gps.time.centisecond());
 			last_value_GPS_datetime = gps_datetime;
+		} else {
+			//define a default value
+			last_value_GPS_datetime = "1970-01-01T00:00:00.000";
 		}
 	}
 

--- a/airrohr-firmware/utils.cpp
+++ b/airrohr-firmware/utils.cpp
@@ -565,3 +565,37 @@ const __FlashStringHelper* loggerDescription(unsigned i) {
     }
     return logger;
 }
+
+
+/*****************************************************************
+ * helper to see if a given string is numeric                    *
+ *****************************************************************/
+bool isNumeric(String str) {
+    unsigned int stringLength = str.length();
+
+    if (stringLength == 0) {
+        return false;
+    }
+
+    boolean seenDecimal = false;
+
+    for(unsigned int i = 0; i < stringLength; ++i) {
+        if (i == 0 && str.charAt(0) == '-') {
+          continue;
+        }
+
+        if (isDigit(str.charAt(i))) {
+            continue;
+        }
+
+        if (str.charAt(i) == '.') {
+            if (seenDecimal) {
+                return false;
+            }
+            seenDecimal = true;
+            continue;
+        }
+        return false;
+    }
+    return true;
+}

--- a/airrohr-firmware/utils.h
+++ b/airrohr-firmware/utils.h
@@ -147,6 +147,8 @@ extern void NPM_cmd(PmSensorCmd2 cmd);
 extern bool NPM_checksum_valid_4(const uint8_t (&data)[4]);
 extern bool NPM_checksum_valid_16(const uint8_t (&data)[16]);
 
+extern bool isNumeric(String str);
+
 extern const __FlashStringHelper* loggerDescription(unsigned i);
 
 #endif


### PR DESCRIPTION
Some fixes for sending GPS_datetime to influxdb and fixes for correctring the name of the measurement.

1:
According to https://github.com/opendata-stuttgart/feinstaub-api/blob/master/feinstaub/sensors/models.py#L119 GPS_datetime should be named GPS_timestamp.

2:
Also influxdb likes to get those values in quotes as string - but other APIs do not, so I used the isNumeric function mostly copied from http://tripsintech.com/arduino-isnumeric-function/ to detect a non-numeric and quote it only for influxdb.

3:
I also added a default value for datetime of '1960-01-01T00:00:00.000' in case the GPS fix is wrong.
I need data on how the Timestamp is used in the APIs, might be worth sending nothing at all if the GPS-Fix is invalid.

4: I changed the sprintf formatting of the GPS_datetime to correctly represent RFC 3339 which I think it should.


This PR fixes #781 