### PR TITLE
Redo fetchSensorGPS() if/else logic for gps_datetime

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -3287,15 +3287,14 @@ static void fetchSensorGPS(String& s) {
 			snprintf_P(gps_time, sizeof(gps_time), PSTR("%02d:%02d:%02d.%02d"),
 				gps.time.hour(), gps.time.minute(), gps.time.second(), gps.time.centisecond());
 			last_value_GPS_time = gps_time;
+			if (gps.date.isValid()) {
+				char gps_datetime[37];
+				snprintf_P(gps_datetime, sizeof(gps_datetime), PSTR("%04d-%02d-%02dT%02d:%02d:%02d.%03d"),
+					gps.date.year(), gps.date.month(), gps.date.day(), gps.time.hour(), gps.time.minute(), gps.time.second(), gps.time.centisecond());
+				last_value_GPS_datetime = gps_datetime;
+			}
 		} else {
 			debug_outln_verbose(F("Time: INVALID"));
-		}
-		if (gps.date.isValid() && gps.time.isValid()) {
-			char gps_datetime[37];
-			snprintf_P(gps_datetime, sizeof(gps_datetime), PSTR("%04d-%02d-%02dT%02d:%02d:%02d.%03d"),
-				gps.date.year(), gps.date.month(), gps.date.day(), gps.time.hour(), gps.time.minute(), gps.time.second(), gps.time.centisecond());
-			last_value_GPS_datetime = gps_datetime;
-		} else {
 			//define a default value
 			last_value_GPS_datetime = F("1970-01-01T00:00:00.000");
 		}


### PR DESCRIPTION
This moves the if/else code for gps_datetime inside the gps.time.isValid() conditional.
It removes one && conditional and one else clause. The code is a bit more 'ugly' but fixes the performance problems in #789