### PR TITLE
Only track GPS as timestamp (#789)

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,3 +1,7 @@
+NRZ-2020-130-B10
+* Show GPS date+time also as datetime timestamp
+* Reduce loop size (Related to #789)
+
 NRZ-2020-130-B9
 * WebUI Styling refresh
 * GPS date+time is now sent as datetime timestamp

--- a/airrohr-firmware/intl_bg.h
+++ b/airrohr-firmware/intl_bg.h
@@ -104,7 +104,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Географска ширина";
 const char INTL_LONGITUDE[] PROGMEM = "Географска дължина";
 const char INTL_ALTITUDE[] PROGMEM = "Надморска височина";
-const char INTL_DATE[] PROGMEM = "Дата";
 const char INTL_TIME_UTC[] PROGMEM = "Дата (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Сила на сигнала";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Качество на сигнала";

--- a/airrohr-firmware/intl_cz.h
+++ b/airrohr-firmware/intl_cz.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Zem. šíøka";
 const char INTL_LONGITUDE[] PROGMEM = "Zem. délka";
 const char INTL_ALTITUDE[] PROGMEM = "Nadm. výška";
-const char INTL_DATE[] PROGMEM = "Datum";
 const char INTL_TIME_UTC[] PROGMEM = "Èas (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Síla signálu";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Kvalita signálu";

--- a/airrohr-firmware/intl_de.h
+++ b/airrohr-firmware/intl_de.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Breite";
 const char INTL_LONGITUDE[] PROGMEM = "Länge";
 const char INTL_ALTITUDE[] PROGMEM = "Höhe";
-const char INTL_DATE[] PROGMEM = "Datum";
 const char INTL_TIME_UTC[] PROGMEM = "Zeit (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Signal";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Qualität";

--- a/airrohr-firmware/intl_dk.h
+++ b/airrohr-firmware/intl_dk.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Breddegrad";
 const char INTL_LONGITUDE[] PROGMEM = "Længdegrad";
 const char INTL_ALTITUDE[] PROGMEM = "Højde";
-const char INTL_DATE[] PROGMEM = "Dato";
 const char INTL_TIME_UTC[] PROGMEM = "Tid (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Signal";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Kvalitet";

--- a/airrohr-firmware/intl_en.h
+++ b/airrohr-firmware/intl_en.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Latitude";
 const char INTL_LONGITUDE[] PROGMEM = "Longitude";
 const char INTL_ALTITUDE[] PROGMEM = "Altitude";
-const char INTL_DATE[] PROGMEM = "Date";
 const char INTL_TIME_UTC[] PROGMEM = "Time (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "signal strength";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "signal quality";

--- a/airrohr-firmware/intl_es.h
+++ b/airrohr-firmware/intl_es.h
@@ -104,7 +104,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Latitud";
 const char INTL_LONGITUDE[] PROGMEM = "Longitud";
 const char INTL_ALTITUDE[] PROGMEM = "Altitud";
-const char INTL_DATE[] PROGMEM = "Fecha";
 const char INTL_TIME_UTC[] PROGMEM = "Tiempo (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Intensidad de Señal";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Calidad de Señal";

--- a/airrohr-firmware/intl_fr.h
+++ b/airrohr-firmware/intl_fr.h
@@ -104,7 +104,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Latitude";
 const char INTL_LONGITUDE[] PROGMEM = "Longitude";
 const char INTL_ALTITUDE[] PROGMEM = "Altitude";
-const char INTL_DATE[] PROGMEM = "Date";
 const char INTL_TIME_UTC[] PROGMEM = "Heure (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Force du signal";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Qualité du signal";

--- a/airrohr-firmware/intl_hu.h
+++ b/airrohr-firmware/intl_hu.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Földrajzi szélesség";
 const char INTL_LONGITUDE[] PROGMEM = "Földrajzi hosszúság";
 const char INTL_ALTITUDE[] PROGMEM = "Tengerszint feletti magasság";
-const char INTL_DATE[] PROGMEM = "Dátum";
 const char INTL_TIME_UTC[] PROGMEM = "Idő";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Jelerősség";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Jelminőség";

--- a/airrohr-firmware/intl_it.h
+++ b/airrohr-firmware/intl_it.h
@@ -104,7 +104,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Latitudine";
 const char INTL_LONGITUDE[] PROGMEM = "Longitudine";
 const char INTL_ALTITUDE[] PROGMEM = "Altitudine";
-const char INTL_DATE[] PROGMEM = "Data";
 const char INTL_TIME_UTC[] PROGMEM = "Ora (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Potenza del segnale";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Qualità del segnale";

--- a/airrohr-firmware/intl_lu.h
+++ b/airrohr-firmware/intl_lu.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Breedegrad";
 const char INTL_LONGITUDE[] PROGMEM = "Längtegrad";
 const char INTL_ALTITUDE[] PROGMEM = "Héicht";
-const char INTL_DATE[] PROGMEM = "Datum";
 const char INTL_TIME_UTC[] PROGMEM = "Zäit (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Signal";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Qualitéit";

--- a/airrohr-firmware/intl_nl.h
+++ b/airrohr-firmware/intl_nl.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Breedtegraad";
 const char INTL_LONGITUDE[] PROGMEM = "Lengtegraad";
 const char INTL_ALTITUDE[] PROGMEM = "Hoogte";
-const char INTL_DATE[] PROGMEM = "Datum";
 const char INTL_TIME_UTC[] PROGMEM = "Tijd (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Signaalsterkte";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Signaalkwaliteit";

--- a/airrohr-firmware/intl_pl.h
+++ b/airrohr-firmware/intl_pl.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Szerokość geo.";
 const char INTL_LONGITUDE[] PROGMEM = "Długość geo.";
 const char INTL_ALTITUDE[] PROGMEM = "Wysokość";
-const char INTL_DATE[] PROGMEM = "Data";
 const char INTL_TIME_UTC[] PROGMEM = "Czas (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Siła sygnału";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Jakość sygnału";

--- a/airrohr-firmware/intl_pt.h
+++ b/airrohr-firmware/intl_pt.h
@@ -104,7 +104,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Latitude";
 const char INTL_LONGITUDE[] PROGMEM = "Longitude";
 const char INTL_ALTITUDE[] PROGMEM = "Altitude";
-const char INTL_DATE[] PROGMEM = "Data";
 const char INTL_TIME_UTC[] PROGMEM = "Hora (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Intensidade do Sinal";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Qualidade do Sinal";

--- a/airrohr-firmware/intl_rs.h
+++ b/airrohr-firmware/intl_rs.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Geografska širina";
 const char INTL_LONGITUDE[] PROGMEM = "Geografska dužina";
 const char INTL_ALTITUDE[] PROGMEM = "Nadmorska visina";
-const char INTL_DATE[] PROGMEM = "Datum";
 const char INTL_TIME_UTC[] PROGMEM = "Vreme (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "jačina signala";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "kvalitet signala";

--- a/airrohr-firmware/intl_ru.h
+++ b/airrohr-firmware/intl_ru.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Широта";
 const char INTL_LONGITUDE[] PROGMEM = "Долгота";
 const char INTL_ALTITUDE[] PROGMEM = "Высота";
-const char INTL_DATE[] PROGMEM = "Дата";
 const char INTL_TIME_UTC[] PROGMEM = "Время (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Сигнал";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Качество";

--- a/airrohr-firmware/intl_se.h
+++ b/airrohr-firmware/intl_se.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Latitud";
 const char INTL_LONGITUDE[] PROGMEM = "Longitud";
 const char INTL_ALTITUDE[] PROGMEM = "Altitud";
-const char INTL_DATE[] PROGMEM = "Datum";
 const char INTL_TIME_UTC[] PROGMEM = "Tid (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "Signal";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "Kvalitet";

--- a/airrohr-firmware/intl_sk.h
+++ b/airrohr-firmware/intl_sk.h
@@ -104,7 +104,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Zem. šírka";
 const char INTL_LONGITUDE[] PROGMEM = "Zem. dĺžka";
 const char INTL_ALTITUDE[] PROGMEM = "Nadm. výška";
-const char INTL_DATE[] PROGMEM = "Dátum";
 const char INTL_TIME_UTC[] PROGMEM = "Čas (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "sila signálu";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "kvalita signálu";

--- a/airrohr-firmware/intl_template.h
+++ b/airrohr-firmware/intl_template.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "";
 const char INTL_LONGITUDE[] PROGMEM = "";
 const char INTL_ALTITUDE[] PROGMEM = "";
-const char INTL_DATE[] PROGMEM = "";
 const char INTL_TIME_UTC[] PROGMEM = "";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "";

--- a/airrohr-firmware/intl_tr.h
+++ b/airrohr-firmware/intl_tr.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Enlem";
 const char INTL_LONGITUDE[] PROGMEM = "Boylam";
 const char INTL_ALTITUDE[] PROGMEM = "Rakım";
-const char INTL_DATE[] PROGMEM = "tarih";
 const char INTL_TIME_UTC[] PROGMEM = "zaman (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "sinyal gücü";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "sinyal kalitesi";

--- a/airrohr-firmware/intl_ua.h
+++ b/airrohr-firmware/intl_ua.h
@@ -105,7 +105,6 @@ const char INTL_LA_MAX[] PROGMEM = "LA max";
 const char INTL_LATITUDE[] PROGMEM = "Широта";
 const char INTL_LONGITUDE[] PROGMEM = "Довгота";
 const char INTL_ALTITUDE[] PROGMEM = "Висота";
-const char INTL_DATE[] PROGMEM = "Дата";
 const char INTL_TIME_UTC[] PROGMEM = "Час (UTC)";
 const char INTL_SIGNAL_STRENGTH[] PROGMEM = "потужність сигналу";
 const char INTL_SIGNAL_QUALITY[] PROGMEM = "якість сигналу";


### PR DESCRIPTION
We were only tracking date and time separately now for the web
ui, and we can just track that as timestamp instead.

This also reduces code size of loop() below 8192 bytes again
which hopefully helps with instability of network connection (#789)