### PR TITLE
Remove FP subroutines from IRAM (#789)

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,3 +1,6 @@
+NRZ-2020-130-B11
+* Remove floating point subroutines from IRAM (related to #789)
+
 NRZ-2020-130-B10
 * Show GPS date+time also as datetime timestamp
 * Reduce loop size (Related to #789)

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -60,7 +60,7 @@
 #include <pgmspace.h>
 
 // increment on change
-#define SOFTWARE_VERSION_STR "NRZ-2020-130-B10"
+#define SOFTWARE_VERSION_STR "NRZ-2020-130-B11"
 String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 /*****************************************************************

--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -24,7 +24,7 @@ build_flags =
   -DVTABLES_IN_FLASH -D BEARSSL_SSL_BASIC
   -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
   -D HTTPCLIENT_1_1_COMPATIBLE=0 -D NO_GLOBAL_SERIAL=0
-  -DNDEBUG
+  -DNDEBUG -DFP_IN_IROM -frandom-seed=b61f78373
 
 build_flags_esp32 =
   -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY
@@ -35,6 +35,7 @@ build_flags_esp32_debug = ${common.build_flags_esp32} -g -Og -fno-inline -DUSING
 board_build.ldscript = eagle.flash.4m3m.ld
 board_build.filesystem = spiffs
 board_build.f_cpu = 160000000L
+
 ; Always depend on specific library versions (wherever possible and only for external libraries)
 ; Keep Library names in the order of their dependencies (leaves at the top)
 ; ESP8266WiFi in both cases is necessary to solve a case sensitivity issue with WiFiUdp.h


### PR DESCRIPTION
This saves about 1kb of IRAM, and it reduces code size, which helps with
loop() runs to stay above 4000 for yet unknown reasons.