### PR TITLE
Return OpenMetrics compatible format

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,3 +1,6 @@
+NRZ-2020-132-B2
+* Adjust /metrics to be OpenMetrics protocol compatible
+
 NRZ-2020-132-B1
 * next beta version
 


### PR DESCRIPTION
The prometheus endpoint can be easily converted into an OpenMetrics
endpoint by adding an "# EOF" extra line at the end, which indicates
that scraping was completed successfully.

Also optimize string allocation / reallocation a bit.