### PR TITLE
update-loader: update to the same arduino core than firmware

### DIFF
--- a/airrohr-update-loader/platformio.ini
+++ b/airrohr-update-loader/platformio.ini
@@ -22,11 +22,11 @@ board_build.f_cpu = 160000000L
 ; Keep Library names in alphabetical order
 lib_deps_external =
 extra_scripts = platformio_script.py
-# This release is reflecting the Arduino Core 2.6.2 release
+# This release is reflecting the Arduino Core 2.7.4 release
 # When the requirement for Arduino Core is raised, this
 # needs to be adjusted to the matching version from
 # https://github.com/platformio/platform-espressif8266/releases
-platform_version = espressif8266@2.3.1
+platform_version = espressif8266@2.6.2
 
 [env]
 ;lib_ldf_mode = chain+  ; automatically detect libraries by the used includes


### PR DESCRIPTION
This should not be necessary, but it shouldn't hurt.