### PR TITLE
Remove favicon listing from header

### DIFF
--- a/airrohr-firmware/Versions.md
+++ b/airrohr-firmware/Versions.md
@@ -1,3 +1,6 @@
+NRZ-2020-132-B3
+* Move favicon.ico fetching last
+
 NRZ-2020-132-B2
 * Adjust /metrics to be OpenMetrics protocol compatible
 * Track last Wifi disconnect reason in Device Status page

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -60,7 +60,7 @@
 #include <pgmspace.h>
 
 // increment on change
-#define SOFTWARE_VERSION_STR "NRZ-2020-132-B2"
+#define SOFTWARE_VERSION_STR "NRZ-2020-132-B3"
 String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 /*****************************************************************
@@ -1847,6 +1847,14 @@ static void webserver_metrics_endpoint() {
 /*****************************************************************
  * Webserver Images                                              *
  *****************************************************************/
+
+static void webserver_favicon() {
+	server.sendHeader(F("Cache-Control"), F("max-age=2592000, public"));
+
+	server.send_P(200, TXT_CONTENT_TYPE_IMAGE_PNG,
+		LUFTDATEN_INFO_LOGO_PNG, LUFTDATEN_INFO_LOGO_PNG_SIZE);
+}
+
 static void webserver_static() {
 	server.sendHeader(F("Cache-Control"), F("max-age=2592000, public"));
 
@@ -1896,6 +1904,7 @@ static void setup_webserver() {
 	server.on(F("/reset"), webserver_reset);
 	server.on(F("/data.json"), webserver_data_json);
 	server.on(F("/metrics"), webserver_metrics_endpoint);
+	server.on(F("/favicon.ico"), webserver_favicon);
 	server.on(F(STATIC_PREFIX), webserver_static);
 	server.onNotFound(webserver_not_found);
 

--- a/airrohr-firmware/html-content.h
+++ b/airrohr-firmware/html-content.h
@@ -70,7 +70,6 @@ input[type=submit]:hover{background:#d44}\
 
 const char WEB_PAGE_HEADER_HEAD[] PROGMEM = "<meta name='viewport' content='width=device-width'/>\
 <link rel='stylesheet' href='" STATIC_PREFIX "?r=css'>\
-<link rel='icon' type='image/png' href='" STATIC_PREFIX "?r=logo'/>\
 </style>\
 </head><body>\
 <div class='canvas'>\


### PR DESCRIPTION
The listing of a favion in the header causes at least Chrome to fetch
the icon immediately, while the page is still loading and validating
CSS and other assets. This leads to parallel execution of requests,
which is hanging as ESP8266 WebServer only processes one request at a
time. This can make the webui appear very unresponsive.

Switch to an implicit favicon.ico fetch, which the browser executes
last, after finishing to load the site content (e.g. after
First-Contentful-Paint).