### PR TITLE
Specify platformio external library dependencies as author/libname

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -43,15 +43,15 @@ board_build.f_cpu = 160000000L
 ;   (like OneWire, LiquidCrystal_I2C and TinyGPSPlus)
 
 lib_deps_external =
-  1@2.3.5 ; OneWire
-  576@1.1.4 ; LiquidCrystal_I2C
-  Adafruit BMP085 Library@1.0.1
-  Adafruit HTU21DF Library@1.0.2
-  Adafruit SHT31 Library@1.1.6
-  ArduinoJson@6.16.1
-  DallasTemperature@3.8.0
-  ESP8266_SSD1306@4.1.0
-  1655@1.0.2 ; TinyGPSPlus, formerly this was referenced as mikalhart/TinyGPSPlus#v0.95
+  paulstoffregen/OneWire@2.3.5
+  marcoschwartz/LiquidCrystal_I2C@1.1.4
+  adafruit/Adafruit BMP085 Library@1.0.1
+  adafruit/Adafruit HTU21DF Library@1.0.2
+  adafruit/Adafruit SHT31 Library@1.1.6
+  bblanchon/ArduinoJson@6.16.1
+  milesburton/DallasTemperature@3.8.0
+  squix78/ESP8266_SSD1306@4.1.0
+  mikalhart/TinyGPSPlus@1.0.2
 
 ; system libraries from platform -> no version number
 lib_deps_esp8266_platform =


### PR DESCRIPTION
This exactly specifies the library and is much clearer than just a library number.

So for exampe, instead of library "576" it now specifies "marcoschwartz/LiquidCrystal_I2C" and the comment can be removed.