### PR TITLE
Extend pw length to 130 bytes

### DIFF
--- a/airrohr-firmware/defines.h
+++ b/airrohr-firmware/defines.h
@@ -11,7 +11,7 @@
 #define HOSTNAME_BASE "airRohr-"
 
 #define LEN_CFG_STRING 65
-#define LEN_CFG_PASSWORD 65
+#define LEN_CFG_PASSWORD 130
 
 #define LEN_WLANSSID 35				// credentials for wifi connection
 


### PR DESCRIPTION
Please consider increasing the maximum password length from 65. InfluxDB tokens are at least 88 characters and are cut off silently at the moment.