### PR TITLE
Fix build failure due to SSD1306.h missing

### DIFF
--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -50,7 +50,7 @@ lib_deps_external =
   adafruit/Adafruit SHT31 Library@1.1.6
   bblanchon/ArduinoJson@6.16.1
   milesburton/DallasTemperature@3.8.0
-  squix78/ESP8266_SSD1306@4.1.0
+  squix78/ESP8266 and ESP32 OLED driver for SSD1306 displays @ ^4.2.0
   mikalhart/TinyGPSPlus@1.0.2
 
 ; system libraries from platform -> no version number


### PR DESCRIPTION
The SSD1306 library used has changed the reference name thus failing to install during build. I've updated with a new name, and to version `4.2.0` from the previous `4.1.0`.

Build passes successfully.