### PR TITLE
Simplify platformio script

### DIFF
--- a/airrohr-firmware/platformio_script.py
+++ b/airrohr-firmware/platformio_script.py
@@ -1,12 +1,7 @@
 Import("env")
-import configparser
 import hashlib
 import os
 import shutil
-from base64 import b64decode
-
-config = configparser.ConfigParser()
-config.read("platformio.ini")
 
 def _file_md5_hexdigest(fname):
     return hashlib.md5(open(fname, 'rb').read()).hexdigest()
@@ -15,9 +10,7 @@ def after_build(source, target, env):
     if not os.path.exists("builds"):
         os.mkdir("builds")
 
-    configName = b64decode(ARGUMENTS.get("PIOENV"))
-    sectionName = 'env:' + configName.decode('utf-8')
-    lang = config.get(sectionName, "lang")
+    lang = env.GetProjectOption('lang')
     target_name = lang.lower()
 
     with open(f"builds/latest_{target_name}.bin.md5", "w") as md5:


### PR DESCRIPTION
This makes use of env.GetProjectOption() instead of parsing platformio.ini separately, to get the 'lang' variable.

I have built the firmwares with both this and with the old settings, clearing the '.pio' and 'builds' directories.
Then I verified that the md5 sums were still the same for a couple of languages.