### PR TITLE
Cleanup: remove call to WiFi.persistent(false)

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -4449,7 +4449,6 @@ void setup(void) {
 	esp_chipid += String((uint32_t)chipid_num, HEX);
 #endif
 	cfg::initNonTrivials(esp_chipid.c_str());
-	WiFi.persistent(false);
 
 	debug_outln_info(F("airRohr: " SOFTWARE_VERSION_STR "/"), String(CURRENT_LANG));
 #if defined(ESP8266)


### PR DESCRIPTION
Beta uses Arduino Core 3.x, which disables WiFi.persistent by default: https://arduino-esp8266.readthedocs.io/en/latest/esp8266wifi/generic-class.html#persistent