### PR TITLE
Make WiFi maximum TX power configurable

### DIFF
--- a/airrohr-firmware/airrohr-cfg.h
+++ b/airrohr-firmware/airrohr-cfg.h
@@ -28,6 +28,7 @@ enum ConfigShapeId {
 	Config_current_lang,
 	Config_wlanssid,
 	Config_wlanpwd,
+	Config_wlanpower,
 	Config_www_username,
 	Config_www_password,
 	Config_fs_ssid,
@@ -97,6 +98,7 @@ enum ConfigShapeId {
 static constexpr char CFG_KEY_CURRENT_LANG[] PROGMEM = "current_lang";
 static constexpr char CFG_KEY_WLANSSID[] PROGMEM = "wlanssid";
 static constexpr char CFG_KEY_WLANPWD[] PROGMEM = "wlanpwd";
+static constexpr char CFG_KEY_WLANPOWER[] PROGMEM = "wlanpower";
 static constexpr char CFG_KEY_WWW_USERNAME[] PROGMEM = "www_username";
 static constexpr char CFG_KEY_WWW_PASSWORD[] PROGMEM = "www_password";
 static constexpr char CFG_KEY_FS_SSID[] PROGMEM = "fs_ssid";
@@ -166,6 +168,7 @@ static constexpr ConfigShapeEntry configShape[] PROGMEM = {
 	{ Config_Type_String, sizeof(cfg::current_lang)-1, CFG_KEY_CURRENT_LANG, cfg::current_lang },
 	{ Config_Type_String, sizeof(cfg::wlanssid)-1, CFG_KEY_WLANSSID, cfg::wlanssid },
 	{ Config_Type_Password, sizeof(cfg::wlanpwd)-1, CFG_KEY_WLANPWD, cfg::wlanpwd },
+	{ Config_Type_Bool, 0, CFG_KEY_WLANPOWER, &cfg::wlanpower },
 	{ Config_Type_String, sizeof(cfg::www_username)-1, CFG_KEY_WWW_USERNAME, cfg::www_username },
 	{ Config_Type_Password, sizeof(cfg::www_password)-1, CFG_KEY_WWW_PASSWORD, cfg::www_password },
 	{ Config_Type_String, sizeof(cfg::fs_ssid)-1, CFG_KEY_FS_SSID, cfg::fs_ssid },

--- a/airrohr-firmware/airrohr-cfg.h.py
+++ b/airrohr-firmware/airrohr-cfg.h.py
@@ -4,6 +4,7 @@ configshape_in = """
 String		current_lang
 String		wlanssid
 Password		wlanpwd
+Bool		wlanpower
 String		www_username
 Password		www_password
 String		fs_ssid

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -143,9 +143,10 @@ namespace cfg {
 	char www_username[LEN_WWW_USERNAME];
 	char www_password[LEN_CFG_PASSWORD];
 
-	// wifi credentials
+	// wifi settings
 	char wlanssid[LEN_WLANSSID];
 	char wlanpwd[LEN_CFG_PASSWORD];
+	bool wlanpower = true;
 	
 	char static_ip[16];
 	char static_subnet[16];
@@ -1113,6 +1114,7 @@ static void webserver_config_send_body_get(String& page_content) {
 	server.sendContent(page_content);
 	page_content = emptyString;
 
+	add_form_checkbox(Config_wlanpower, FPSTR(INTL_WIFI_TXPOWER));
 	add_form_checkbox(Config_www_basicauth_enabled, FPSTR(INTL_BASICAUTH));
 	page_content += FPSTR(TABLE_TAG_OPEN);
 	add_form_input(page_content, Config_www_username, FPSTR(INTL_USER), LEN_WWW_USERNAME-1);
@@ -2179,8 +2181,10 @@ static void connectWifi() {
 #if defined(ESP8266)
 	// Enforce Rx/Tx calibration
 	system_phy_set_powerup_option(1);
-	// 20dBM == 100mW == max tx power allowed in europe
-	WiFi.setOutputPower(20.0f);
+	if (cfg::wlanpower) {
+		// 20dBM == 100mW == max tx power allowed in europe
+		WiFi.setOutputPower(20.0f);
+	}
 	WiFi.setSleepMode(WIFI_NONE_SLEEP);
 	WiFi.setPhyMode(WIFI_PHY_MODE_11N);
 	delay(100);

--- a/airrohr-firmware/intl_en.h
+++ b/airrohr-firmware/intl_en.h
@@ -39,6 +39,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Above sea level (m)";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "pressure at sea level";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Authentication";
+const char INTL_WIFI_TXPOWER[] PROGMEM = "Maximum WiFi power";
 #define INTL_REPORT_ISSUE "Report an issue"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi Sensor in configuration mode";

--- a/airrohr-firmware/intl_nl.h
+++ b/airrohr-firmware/intl_nl.h
@@ -38,6 +38,7 @@ const char INTL_TEMP_CORRECTION[] PROGMEM = "Correctie in °C";
 const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Hoogte boven zeeniveau (m)";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "Luchtdruk op zeeniveau";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
+const char INTL_WIFI_TXPOWER[] PROGMEM = "Maximaal WiFi-vermogen";
 const char INTL_BASICAUTH[] PROGMEM = "Toegang beperken";
 #define INTL_REPORT_ISSUE "Een probleem melden"
 


### PR DESCRIPTION
In an effort to save power, make this option configurable. The default is `true`, which equals the current behavior of maximizing TX power.