### PR TITLE
Add power savings (experimental)

### DIFF
--- a/airrohr-firmware/airrohr-cfg.h
+++ b/airrohr-firmware/airrohr-cfg.h
@@ -77,6 +77,7 @@ enum ConfigShapeId {
 	Config_debug,
 	Config_sending_intervall_ms,
 	Config_time_for_wifi_config,
+	Config_powersave,
 	Config_senseboxid,
 	Config_send2custom,
 	Config_host_custom,
@@ -146,6 +147,7 @@ static constexpr char CFG_KEY_STATIC_DNS[] PROGMEM = "static_dns";
 static constexpr char CFG_KEY_DEBUG[] PROGMEM = "debug";
 static constexpr char CFG_KEY_SENDING_INTERVALL_MS[] PROGMEM = "sending_intervall_ms";
 static constexpr char CFG_KEY_TIME_FOR_WIFI_CONFIG[] PROGMEM = "time_for_wifi_config";
+static constexpr char CFG_KEY_POWERSAVE[] PROGMEM = "powersave";
 static constexpr char CFG_KEY_SENSEBOXID[] PROGMEM = "senseboxid";
 static constexpr char CFG_KEY_SEND2CUSTOM[] PROGMEM = "send2custom";
 static constexpr char CFG_KEY_HOST_CUSTOM[] PROGMEM = "host_custom";
@@ -215,6 +217,7 @@ static constexpr ConfigShapeEntry configShape[] PROGMEM = {
 	{ Config_Type_UInt, 0, CFG_KEY_DEBUG, &cfg::debug },
 	{ Config_Type_Time, 0, CFG_KEY_SENDING_INTERVALL_MS, &cfg::sending_intervall_ms },
 	{ Config_Type_Time, 0, CFG_KEY_TIME_FOR_WIFI_CONFIG, &cfg::time_for_wifi_config },
+	{ Config_Type_Bool, 0, CFG_KEY_POWERSAVE, &cfg::powersave },
 	{ Config_Type_String, sizeof(cfg::senseboxid)-1, CFG_KEY_SENSEBOXID, cfg::senseboxid },
 	{ Config_Type_Bool, 0, CFG_KEY_SEND2CUSTOM, &cfg::send2custom },
 	{ Config_Type_String, sizeof(cfg::host_custom)-1, CFG_KEY_HOST_CUSTOM, cfg::host_custom },

--- a/airrohr-firmware/airrohr-cfg.h.py
+++ b/airrohr-firmware/airrohr-cfg.h.py
@@ -53,6 +53,7 @@ String		static_dns
 UInt		debug
 Time		sending_intervall_ms
 Time		time_for_wifi_config
+Bool		powersave
 String		senseboxid
 Bool		send2custom
 String		host_custom

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -135,6 +135,7 @@ namespace cfg
 	
 	unsigned time_for_wifi_config = 600000;
 	unsigned sending_intervall_ms = 145000;
+	bool powersave;
 
 	char current_lang[3];
 
@@ -1538,6 +1539,7 @@ static void webserver_config_send_body_get(String &page_content)
 	page_content += FPSTR(WEB_B_BR);
 	page_content += FPSTR(BR_TAG);
 
+	add_form_checkbox(Config_powersave, FPSTR(INTL_POWERSAVE));
 	page_content += FPSTR(TABLE_TAG_OPEN);
 	add_form_input(page_content, Config_debug, FPSTR(INTL_DEBUG_LEVEL), 1);
 	add_form_input(page_content, Config_sending_intervall_ms, FPSTR(INTL_MEASUREMENT_INTERVAL), 5);
@@ -2696,7 +2698,11 @@ static void connectWifi()
 	system_phy_set_powerup_option(1);
 	// 20dBM == 100mW == max tx power allowed in europe
 	WiFi.setOutputPower(20.0f);
-	WiFi.setSleepMode(WIFI_NONE_SLEEP);
+	if (cfg::powersave) {
+		WiFi.setSleepMode(WIFI_MODEM_SLEEP);
+	} else {
+		WiFi.setSleepMode(WIFI_NONE_SLEEP);
+	}
 	WiFi.setPhyMode(WIFI_PHY_MODE_11N);
 	delay(100);
 
@@ -5297,6 +5303,8 @@ void setup(void)
  *****************************************************************/
 void loop(void)
 {
+	unsigned long sleep = SLEEPTIME_MS;
+
 	String result_PPD, result_SDS, result_PMS, result_HPM, result_NPM;
 	String result_GPS, result_DNMS;
 
@@ -5596,6 +5604,7 @@ void loop(void)
 		starttime = millis(); // store the start time
 		count_sends++;
 	}
+
 #if defined(ESP8266)
 	MDNS.update();
 	if (cfg::npm_read)
@@ -5608,6 +5617,12 @@ void loop(void)
 	}
 
 #endif
+
+	// Sleep if all of the tasks have an event in the future. The chip can then
+	// enter a lower power mode.
+	if (cfg::powersave) {
+		delay(sleep);
+	}
 
 	if (sample_count % 500 == 0)
 	{

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -5313,8 +5313,13 @@ void loop(void)
 	act_micro = micros();
 	act_milli = millis();
 	send_now = msSince(starttime) > cfg::sending_intervall_ms;
-	// Wait at least 30s for each NTP server to sync
 
+	if (send_now)
+	{
+		sleep = 0;
+	}
+
+	// Wait at least 30s for each NTP server to sync
 	if (!sntp_time_set && send_now &&
 		msSince(time_point_device_start_ms) < 1000 * 2 * 30 + 5000)
 	{

--- a/airrohr-firmware/defines.h
+++ b/airrohr-firmware/defines.h
@@ -46,6 +46,7 @@
 /******************************************************************
  * Constants                                                      *
  ******************************************************************/
+constexpr const unsigned long SLEEPTIME_MS = 250;
 constexpr const unsigned long SAMPLETIME_MS = 30000;									// time between two measurements of the PPD42NS
 constexpr const unsigned long SAMPLETIME_SDS_MS = 1000;								// time between two measurements of the SDS011, PMSx003, Honeywell PM sensor
 constexpr const unsigned long WARMUPTIME_SDS_MS = 15000;								// time needed to "warm up" the sensor before we can take the first measurement

--- a/airrohr-firmware/intl_en.h
+++ b/airrohr-firmware/intl_en.h
@@ -65,6 +65,7 @@ const char INTL_STATIC_DNS[] PROGMEM = "DNS server";
 const char INTL_DEBUG_LEVEL[] PROGMEM = "Debug&nbsp;level";
 const char INTL_MEASUREMENT_INTERVAL[] PROGMEM = "Measuring interval (sec)";
 const char INTL_DURATION_ROUTER_MODE[] PROGMEM = "Duration router mode";
+const char INTL_POWERSAVE[] PROGMEM = "Power saving";
 const char INTL_MORE_APIS[] PROGMEM = "More APIs";
 const char INTL_SEND_TO_OWN_API[] PROGMEM = "Send data to custom API";
 const char INTL_SERVER[] PROGMEM = "Server";

--- a/airrohr-firmware/intl_nl.h
+++ b/airrohr-firmware/intl_nl.h
@@ -65,6 +65,7 @@ const char INTL_STATIC_DNS[] PROGMEM = "DNS-server";
 const char INTL_DEBUG_LEVEL[] PROGMEM = "Debugniveau";
 const char INTL_MEASUREMENT_INTERVAL[] PROGMEM = "Meetinterval";
 const char INTL_DURATION_ROUTER_MODE[] PROGMEM = "Tijdsduur routermodus";
+const char INTL_POWERSAVE[] PROGMEM = "Energiebesparing";
 const char INTL_MORE_APIS[] PROGMEM = "Meer API's";
 const char INTL_SEND_TO_OWN_API[] PROGMEM = "Verzend data naar eigen API";
 const char INTL_SERVER[] PROGMEM = "Serveradres";


### PR DESCRIPTION
The `loop()` method is burning a lot of cycles when idle. By adding some delay, in combination with `WIFI_MODEM_SLEEP`, it is possible to save power. The current sleep interval of 250 ms is an educated guess, but seems to work fine: it is much less than the amount of time the sensor 'blocks' when transmitting measurements. This might not work with all sensors, but I have good experience with SDS011, BME280 and GPS NEO-6M.

Using a power profiler, I was able to reduce the average idle consumption from ~100 mA to ~60 mA (measured at the USB port). This also reduces self-heating of the enclosure I use by a lot.

This is the first step. I am testing some additions to this PR, where the amount of sleep is 'optimized' in the loop. If some sensor needs an update within the next X ms, then X is used instead of a fixed 250 ms.

I opened this PR for discussion and feedback.