### PR TITLE
Fixed Str2F conversion error in Offsetcalculation

### DIFF
--- a/airrohr-firmware/utils.cpp
+++ b/airrohr-firmware/utils.cpp
@@ -243,9 +243,16 @@ void add_Value2Json(String& res, const __FlashStringHelper* type, const __FlashS
 float readCorrectionOffset(const char* correction) {
 	char* pEnd = nullptr;
 	// Avoiding atof() here as this adds a lot (~ 9kb) of code size
+	// which btw is really bad, because now we have a lot more work for everyone
+	// TODO: fix this mess to use fixed point
 	float r = float(strtol(correction, &pEnd, 10));
 	if (pEnd && pEnd[0] == '.' && pEnd[1] >= '0' && pEnd[1] <= '9') {
-		r += (r >= 0.0f ? 1.0f : -1.0f) * ((pEnd[1] - '0') / 10.0f);
+		bool isNegative = correction[0] == '-';
+		for (int i = 0; correction[i] == ' '; i++) {
+			isNegative = correction[i + 1] == '-';
+		}
+
+		r += (isNegative ? -1.0f : 1.0f) * ((pEnd[1] - '0') / 10.0f);
 	}
 	return r;
 }


### PR DESCRIPTION
# Description

When offsetting the temperature by any value between (but not including) -1.0 and 0, the offset would be calculated to the absolute value, introduced in #607 

# Example

When offsetting by -0.7, the offset would be calculated to 0.7

`float r = float(strtol(correction, &pEnd, 10));` returns 0, thus check `r >= 0.0f ? 1.0f : -1.0f` returns 1.0f, 0.7 would be added instead of subtracted

# Reproduction

Reproducable by going into configuration/sensors and changing the temperature offset to anything between -1.0 and 0, the temperature will be offset by the absolute value, not the negative value

# Fix

Changed to check for a leading "-" (after spaces) instead, but it requires a loop or using std::string and trimming that, which would be a more major change (possibly trimming the string when it is put into the config would save on resources)

# Btw

Just an idea I had, could we use fixed point for everything temperature? The software only reads one digit, the offset only does one digit, it feels like, especially on a microcontroller, we should avoid floats alltogether, because then we get issues like this. Would be quite a rewrite tho, I suspect.

Or, yk, use atof 😉

