### PR TITLE
patch to re-enable the ability to use WiFi with no password, like freifunk routers use to use.

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -57,7 +57,7 @@
 #include <pgmspace.h>
 
 // increment on change
-#define SOFTWARE_VERSION_STR "NRZ-2021-134-B5"
+#define SOFTWARE_VERSION_STR "NRZ-2023-134-B5"
 String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 /*****************************************************************

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -57,7 +57,7 @@
 #include <pgmspace.h>
 
 // increment on change
-#define SOFTWARE_VERSION_STR "NRZ-2021-134-B4"
+#define SOFTWARE_VERSION_STR "NRZ-2021-134-B5"
 String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 /*****************************************************************
@@ -2851,7 +2851,14 @@ static void wifiConfig()
 
 	debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
 
-	WiFi.begin(cfg::wlanssid, cfg::wlanpwd);
+	if( *cfg::wlanpwd ) // non-empty password
+	{
+		WiFi.begin(cfg::wlanssid, cfg::wlanpwd);
+	}
+	else  // empty password: WiFi AP without a password, e.g. "freifunk" or the like
+	{
+		WiFi.begin(cfg::wlanssid); // since somewhen, the espressif API changed semantics: no password need the 1 args call since.
+	}
 
 	debug_outln_info(F("---- Result Webconfig ----"));
 	debug_outln_info(F("WLANSSID: "), cfg::wlanssid);


### PR DESCRIPTION
as pointed by mail some days ago, this is the patch to make the Airrohr able to use Freifunk routers again. I worked in quite early versions, but between 2018 and 2021 the semantics of the espressif API changed (apparently when WPA3 came up), giving an empty password as argument 2 didn't worked anymore with WPA2/3 APs.
Tested with Joy-IT OR750i Router running Freifunk-Hannover Firmware vH34 / gluon-v2022.1.3 which is the same compared to Freifunk-Stuttgart, except the preset routing.

Would highly appreciate to see this in the master soon ;-)
