### PR TITLE
Patch/freifunk fix2

### DIFF
--- a/airrohr-firmware/airrohr-cfg.h
+++ b/airrohr-firmware/airrohr-cfg.h
@@ -33,6 +33,7 @@ enum ConfigShapeId {
 	Config_fs_ssid,
 	Config_fs_pwd,
 	Config_www_basicauth_enabled,
+	Config_wlan_nopwd_enabled,
 	Config_dht_read,
 	Config_htu21d_read,
 	Config_ppd_read,
@@ -105,6 +106,7 @@ static constexpr char CFG_KEY_WWW_PASSWORD[] PROGMEM = "www_password";
 static constexpr char CFG_KEY_FS_SSID[] PROGMEM = "fs_ssid";
 static constexpr char CFG_KEY_FS_PWD[] PROGMEM = "fs_pwd";
 static constexpr char CFG_KEY_WWW_BASICAUTH_ENABLED[] PROGMEM = "www_basicauth_enabled";
+static constexpr char CFG_KEY_WLAN_NOPWD_ENABLED[] PROGMEM = "wlan_nopwd_enabled";
 static constexpr char CFG_KEY_DHT_READ[] PROGMEM = "dht_read";
 static constexpr char CFG_KEY_HTU21D_READ[] PROGMEM = "htu21d_read";
 static constexpr char CFG_KEY_PPD_READ[] PROGMEM = "ppd_read";
@@ -177,6 +179,7 @@ static constexpr ConfigShapeEntry configShape[] PROGMEM = {
 	{ Config_Type_String, sizeof(cfg::fs_ssid)-1, CFG_KEY_FS_SSID, cfg::fs_ssid },
 	{ Config_Type_Password, sizeof(cfg::fs_pwd)-1, CFG_KEY_FS_PWD, cfg::fs_pwd },
 	{ Config_Type_Bool, 0, CFG_KEY_WWW_BASICAUTH_ENABLED, &cfg::www_basicauth_enabled },
+	{ Config_Type_Bool, 0, CFG_KEY_WLAN_NOPWD_ENABLED, &cfg::wlan_nopwd_enabled },
 	{ Config_Type_Bool, 0, CFG_KEY_DHT_READ, &cfg::dht_read },
 	{ Config_Type_Bool, 0, CFG_KEY_HTU21D_READ, &cfg::htu21d_read },
 	{ Config_Type_Bool, 0, CFG_KEY_PPD_READ, &cfg::ppd_read },

--- a/airrohr-firmware/airrohr-cfg.h.py
+++ b/airrohr-firmware/airrohr-cfg.h.py
@@ -9,6 +9,7 @@ Password		www_password
 String		fs_ssid
 Password		fs_pwd
 Bool		www_basicauth_enabled
+Bool		wlan_nopwd_enabled
 Bool		dht_read
 Bool		htu21d_read
 Bool		ppd_read

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -2868,14 +2868,14 @@ static void wifiConfig()
 	dnsServer.stop();
 	delay(100);
 
-	debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
-
 	if( *cfg::wlanpwd && !cfg::wlan_nopwd_enabled ) // non-empty password
 	{
+		debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
 		WiFi.begin(cfg::wlanssid, cfg::wlanpwd);
 	}
 	else  // empty password: WiFi AP without a password, e.g. "freifunk" or the like
 	{
+		debug_outln_info(FPSTR(DBG_TXT_CONNECTING_NOPWD_TO), cfg::wlanssid);
 		WiFi.begin(cfg::wlanssid); // since somewhen, the espressif API changed semantics: no password need the 1 args call since.
 	}
 
@@ -2981,14 +2981,15 @@ static void connectWifi()
 
 	if( *cfg::wlanpwd && !cfg::wlan_nopwd_enabled ) // non-empty password
 	{
+		debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
 		WiFi.begin(cfg::wlanssid, cfg::wlanpwd); // Start WiFI
 	}
 	else  // empty password: WiFi AP without a password, e.g. "freifunk" or the like
 	{
+		debug_outln_info(FPSTR(DBG_TXT_CONNECTING_NOPWD_TO), cfg::wlanssid);
 		WiFi.begin(cfg::wlanssid); // since somewhen, the espressif API changed semantics: no password need arg 2 to be nullptr (or omitted) since.
 	}
 	
-	debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
 
 	waitForWifiToConnect(40);  // xx half seconds
 	debug_outln_info(emptyString);

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -1655,7 +1655,6 @@ static void webserver_config_send_body_get(String &page_content)
 	}
 	page_content += FPSTR(TABLE_TAG_OPEN);
 	add_form_checkbox(Config_wlan_nopwd_enabled, FPSTR(INTL_NOPWD));
-	static constexpr char CFG_KEY_WLAN_NOPWD_ENABLED[] PROGMEM = "wlan_nopwd_enabled";
 	add_form_input(page_content, Config_wlanssid, FPSTR(INTL_FS_WIFI_NAME), LEN_WLANSSID - 1);
 	add_form_input(page_content, Config_wlanpwd, FPSTR(INTL_PASSWORD), LEN_CFG_PASSWORD - 1);
 	page_content += FPSTR(TABLE_TAG_CLOSE_BR);
@@ -2868,14 +2867,14 @@ static void wifiConfig()
 	dnsServer.stop();
 	delay(100);
 
-	debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
-
 	if( *cfg::wlanpwd && !cfg::wlan_nopwd_enabled ) // non-empty password
 	{
+		debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
 		WiFi.begin(cfg::wlanssid, cfg::wlanpwd);
 	}
 	else  // empty password: WiFi AP without a password, e.g. "freifunk" or the like
 	{
+		debug_outln_info(FPSTR(DBG_TXT_CONNECTING_NOPWD_TO), cfg::wlanssid);
 		WiFi.begin(cfg::wlanssid); // since somewhen, the espressif API changed semantics: no password need the 1 args call since.
 	}
 
@@ -2981,14 +2980,15 @@ static void connectWifi()
 
 	if( *cfg::wlanpwd && !cfg::wlan_nopwd_enabled ) // non-empty password
 	{
+		debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
 		WiFi.begin(cfg::wlanssid, cfg::wlanpwd); // Start WiFI
 	}
 	else  // empty password: WiFi AP without a password, e.g. "freifunk" or the like
 	{
+		debug_outln_info(FPSTR(DBG_TXT_CONNECTING_NOPWD_TO), cfg::wlanssid);
 		WiFi.begin(cfg::wlanssid); // since somewhen, the espressif API changed semantics: no password need arg 2 to be nullptr (or omitted) since.
 	}
 	
-	debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
 
 	waitForWifiToConnect(40);  // xx half seconds
 	debug_outln_info(emptyString);

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -146,6 +146,7 @@ namespace cfg
 	char www_password[LEN_CFG_PASSWORD];
 
 	// wifi credentials
+	bool wlan_nopwd_enabled = WLAN_NOPWD_ENABLED;
 	char wlanssid[LEN_WLANSSID];
 	char wlanpwd[LEN_CFG_PASSWORD];
 
@@ -1653,6 +1654,8 @@ static void webserver_config_send_body_get(String &page_content)
 		page_content += F("<div id='wifilist'>" INTL_WIFI_NETWORKS "</div><br/>");
 	}
 	page_content += FPSTR(TABLE_TAG_OPEN);
+	add_form_checkbox(Config_wlan_nopwd_enabled, FPSTR(INTL_NOPWD));
+	static constexpr char CFG_KEY_WLAN_NOPWD_ENABLED[] PROGMEM = "wlan_nopwd_enabled";
 	add_form_input(page_content, Config_wlanssid, FPSTR(INTL_FS_WIFI_NAME), LEN_WLANSSID - 1);
 	add_form_input(page_content, Config_wlanpwd, FPSTR(INTL_PASSWORD), LEN_CFG_PASSWORD - 1);
 	page_content += FPSTR(TABLE_TAG_CLOSE_BR);
@@ -2867,7 +2870,7 @@ static void wifiConfig()
 
 	debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
 
-	if( *cfg::wlanpwd ) // non-empty password
+	if( *cfg::wlanpwd && !cfg::wlan_nopwd_enabled ) // non-empty password
 	{
 		WiFi.begin(cfg::wlanssid, cfg::wlanpwd);
 	}
@@ -2976,7 +2979,7 @@ static void connectWifi()
 	WiFi.setHostname(cfg::fs_ssid);
 #endif
 
-	if( *cfg::wlanpwd ) // non-empty password
+	if( *cfg::wlanpwd && !cfg::wlan_nopwd_enabled ) // non-empty password
 	{
 		WiFi.begin(cfg::wlanssid, cfg::wlanpwd); // Start WiFI
 	}
@@ -2987,7 +2990,7 @@ static void connectWifi()
 	
 	debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
 
-	waitForWifiToConnect(40);
+	waitForWifiToConnect(40);  // xx half seconds
 	debug_outln_info(emptyString);
 	if (WiFi.status() != WL_CONNECTED)
 	{

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -58,7 +58,7 @@
 #include <pgmspace.h>
 
 // increment on change
-#define SOFTWARE_VERSION_STR "NRZ-2024-136-B1"
+#define SOFTWARE_VERSION_STR "NRZ-2024-135"
 String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 
 /*****************************************************************

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -2976,8 +2976,15 @@ static void connectWifi()
 	WiFi.setHostname(cfg::fs_ssid);
 #endif
 
-	WiFi.begin(cfg::wlanssid, cfg::wlanpwd); // Start WiFI
-
+	if( *cfg::wlanpwd ) // non-empty password
+	{
+		WiFi.begin(cfg::wlanssid, cfg::wlanpwd); // Start WiFI
+	}
+	else  // empty password: WiFi AP without a password, e.g. "freifunk" or the like
+	{
+		WiFi.begin(cfg::wlanssid); // since somewhen, the espressif API changed semantics: no password need arg 2 to be nullptr (or omitted) since.
+	}
+	
 	debug_outln_info(FPSTR(DBG_TXT_CONNECTING_TO), cfg::wlanssid);
 
 	waitForWifiToConnect(40);

--- a/airrohr-firmware/ext_def.h
+++ b/airrohr-firmware/ext_def.h
@@ -4,6 +4,7 @@
 // Wifi config
 const char WLANSSID[] PROGMEM = "Freifunk-disabled";
 const char WLANPWD[] PROGMEM = "";
+#define WLAN_NOPWD_ENABLED 0
 
 // BasicAuth config
 const char WWW_USERNAME[] PROGMEM = "admin";

--- a/airrohr-firmware/html-content.h
+++ b/airrohr-firmware/html-content.h
@@ -21,6 +21,7 @@ const char DBG_TXT_SENDING_TO[] PROGMEM = "## Sending to ";
 const char DBG_TXT_SDS011_VERSION_DATE[] PROGMEM = "SDS011 version date";
 const char DBG_TXT_NPM_VERSION_DATE[] PROGMEM = "Next PM version date";
 const char DBG_TXT_CONNECTING_TO[] PROGMEM = "Connecting to ";
+const char DBG_TXT_CONNECTING_NOPWD_TO[] PROGMEM = "Connecting w/o passwd ";
 const char DBG_TXT_FOUND[] PROGMEM = " ... found";
 const char DBG_TXT_NOT_FOUND[] PROGMEM = " ... not found";
 const char DBG_TXT_SEP[] PROGMEM = "----";

--- a/airrohr-firmware/intl_bg.h
+++ b/airrohr-firmware/intl_bg.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Над морското ни�
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "Налягане на морското ниво";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Оторизация";
+const char INTL_NOPWD[] PROGMEM = "без WiFi парола";
 #define INTL_REPORT_ISSUE "Подаване на сигнал за проблем"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi сензор в режим на конфигуриране";

--- a/airrohr-firmware/intl_br.h
+++ b/airrohr-firmware/intl_br.h
@@ -41,6 +41,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Autorização";
+const char INTL_NOPWD[] PROGMEM = "sem senha WiFi";
 #define INTL_REPORT_ISSUE "Reporter um problema"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Nome do sensor Wi-Fi em modo de configuração";

--- a/airrohr-firmware/intl_cn.h
+++ b/airrohr-firmware/intl_cn.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS（NEO 6M）";
 const char INTL_BASICAUTH[] PROGMEM = "认证";
+const char INTL_NOPWD[] PROGMEM = "没有WiFi密码";
 #define INTL_REPORT_ISSUE "报告问题"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi传感器在配置模式下";

--- a/airrohr-firmware/intl_cz.h
+++ b/airrohr-firmware/intl_cz.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Přihlášení";
+const char INTL_NOPWD[] PROGMEM = "bez hesla WiFi";
 #define INTL_REPORT_ISSUE "Nahlásit problém"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Wi-Fi modul v konfiguračním módu";

--- a/airrohr-firmware/intl_de.h
+++ b/airrohr-firmware/intl_de.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Höhe über Meeresspiegel (m)
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "Luftdruck auf Meereshöhe";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "BasicAuth aktivieren";
+const char INTL_NOPWD[] PROGMEM = "ohne WLAN Passwort";
 #define INTL_REPORT_ISSUE "Ein Problem melden"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Sensor WLAN Name im Konfigurationsmodus";

--- a/airrohr-firmware/intl_dk.h
+++ b/airrohr-firmware/intl_dk.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Aktiver BasicAuth";
+const char INTL_NOPWD[] PROGMEM = "uden WiFi-adgangskode";
 #define INTL_REPORT_ISSUE "Rapporter et problem"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Wi-Fi sensor i opsætningsmode";

--- a/airrohr-firmware/intl_ee.h
+++ b/airrohr-firmware/intl_ee.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Autentimine";
+const char INTL_NOPWD[] PROGMEM = "ilma WiFi paroolita";
 #define INTL_REPORT_ISSUE "Teatage probleemist"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi andur konfigureerimisrežiimis";

--- a/airrohr-firmware/intl_en.h
+++ b/airrohr-firmware/intl_en.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Above sea level (m)";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "pressure at sea level";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Authentication";
+const char INTL_NOPWD[] PROGMEM = "no WiFi password";
 #define INTL_REPORT_ISSUE "Report an issue"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi Sensor in configuration mode";

--- a/airrohr-firmware/intl_es.h
+++ b/airrohr-firmware/intl_es.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Autorización";
+const char INTL_NOPWD[] PROGMEM = "sin contraseña wifi";
 #define INTL_REPORT_ISSUE "Reportar un problema"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Sensor WiFi en modo de configuración";

--- a/airrohr-firmware/intl_fi.h
+++ b/airrohr-firmware/intl_fi.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Tunnistus";
+const char INTL_NOPWD[] PROGMEM = "[[no WiFi password]]";
 #define INTL_REPORT_ISSUE "Ilmoita asiasta"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi Sensor konfigurointitilassa";

--- a/airrohr-firmware/intl_fr.h
+++ b/airrohr-firmware/intl_fr.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Altitude en m";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "Press. atm. au niveau de la mer en hPa";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Activer BasicAuth";
+const char INTL_NOPWD[] PROGMEM = "Sans mot de passe WiFi";
 #define INTL_REPORT_ISSUE "Signaler un problème"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Nom du capteur wifi en mode de configuration";

--- a/airrohr-firmware/intl_gr.h
+++ b/airrohr-firmware/intl_gr.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Αυθεντικοποίηση";
+const char INTL_NOPWD[] PROGMEM = "Χωρίς κωδικό πρόσβασης WiFi";
 #define INTL_REPORT_ISSUE "Αναφέρετε ένα θέμα"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Αισθητήρας WiFi σε λειτουργία διαμόρφωσης";

--- a/airrohr-firmware/intl_hu.h
+++ b/airrohr-firmware/intl_hu.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Azonosítás";
+const char INTL_NOPWD[] PROGMEM = "no WiFi password";
 #define INTL_REPORT_ISSUE "Jelents egy hibát"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi Szenzor konfigurációs módban";

--- a/airrohr-firmware/intl_it.h
+++ b/airrohr-firmware/intl_it.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[Altitudine]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[Pressione al livello del mare]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Autorizzazione";
+const char INTL_NOPWD[] PROGMEM = "Senza password Wi-Fi";
 #define INTL_REPORT_ISSUE "Segnala un problema"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Sensore WiFi in modalità configurazione";

--- a/airrohr-firmware/intl_jp.h
+++ b/airrohr-firmware/intl_jp.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "認証";
+const char INTL_NOPWD[] PROGMEM = "[[no WiFi password]]";
 #define INTL_REPORT_ISSUE "問題を報告する"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "設定モードのWiFiセンサー";

--- a/airrohr-firmware/intl_lt.h
+++ b/airrohr-firmware/intl_lt.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Autentiškumo nustatymas";
+const char INTL_NOPWD[] PROGMEM = "[[no WiFi password]]";
 #define INTL_REPORT_ISSUE "Pranešti apie problemą"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi jutiklio konfigūravimo režimas";

--- a/airrohr-firmware/intl_lu.h
+++ b/airrohr-firmware/intl_lu.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "BasicAuth aktivéieren";
+const char INTL_NOPWD[] PROGMEM = "[[no WiFi password]]";
 #define INTL_REPORT_ISSUE "E Feeler melden"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi Sensor Numm am Konfiguratiounsmodus";

--- a/airrohr-firmware/intl_lv.h
+++ b/airrohr-firmware/intl_lv.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Autentifikācija";
+const char INTL_NOPWD[] PROGMEM = "no WiFi password";
 #define INTL_REPORT_ISSUE "Ziņot par problēmu"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi sensors konfigurācijas režīmā";

--- a/airrohr-firmware/intl_nl.h
+++ b/airrohr-firmware/intl_nl.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Hoogte boven zeeniveau (m)";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "Luchtdruk op zeeniveau";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Toegang beperken";
+const char INTL_NOPWD[] PROGMEM = "zonder wifi-wachtwoord";
 #define INTL_REPORT_ISSUE "Een probleem melden"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Netwerknaam en -wachtwoord van de fijnstofsensor";

--- a/airrohr-firmware/intl_pl.h
+++ b/airrohr-firmware/intl_pl.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Wysokość m n.p.m.";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "Ciśnienie zredukowane";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Autoryzacja";
+const char INTL_NOPWD[] PROGMEM = "bez hasła WiFi";
 #define INTL_REPORT_ISSUE "Zgłoś problem"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Parametry WiFi w trybie konfiguracji czujnika";

--- a/airrohr-firmware/intl_pt.h
+++ b/airrohr-firmware/intl_pt.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Autorização";
+const char INTL_NOPWD[] PROGMEM = "sem senha WiFi";
 #define INTL_REPORT_ISSUE "Comunicar um problema"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Nome do sensor WiFi em modo de configuração";

--- a/airrohr-firmware/intl_ro.h
+++ b/airrohr-firmware/intl_ro.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Autentificare";
+const char INTL_NOPWD[] PROGMEM = "Fără parolă WiFi";
 #define INTL_REPORT_ISSUE "Raportați o problemă"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Senzorul WiFi în modul de configurare";

--- a/airrohr-firmware/intl_rs.h
+++ b/airrohr-firmware/intl_rs.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Autorizacija";
+const char INTL_NOPWD[] PROGMEM = "bez WiFi lozinke";
 #define INTL_REPORT_ISSUE "Prijavite problem"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi senzor u konfiguracionom režimu";

--- a/airrohr-firmware/intl_ru.h
+++ b/airrohr-firmware/intl_ru.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Высота над уров�
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "Давление на уровне моря";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Активировать аутентификацию для входа в интерфейс сенсора";
+const char INTL_NOPWD[] PROGMEM = "без пароля Wi-Fi";
 #define INTL_REPORT_ISSUE "Сообщить о проблеме"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Название WiFi устройства в режиме конфигурации";

--- a/airrohr-firmware/intl_se.h
+++ b/airrohr-firmware/intl_se.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Höjd över havet";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "Lufttryck vid havsytan";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Aktivera BasicAuth";
+const char INTL_NOPWD[] PROGMEM = "[[no WiFi password]]";
 #define INTL_REPORT_ISSUE "Rapportera ett problem"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi-sensor i konfigurationsläge";

--- a/airrohr-firmware/intl_si.h
+++ b/airrohr-firmware/intl_si.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Preverjanje pristnosti";
+const char INTL_NOPWD[] PROGMEM = "Bez hesla WiFi";
 #define INTL_REPORT_ISSUE "Prijavite težavo"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Senzor WiFi v načinu konfiguracije";

--- a/airrohr-firmware/intl_sk.h
+++ b/airrohr-firmware/intl_sk.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Prihlásenie (heslom)";
+const char INTL_NOPWD[] PROGMEM = "Žiadne heslo WiFi";
 #define INTL_REPORT_ISSUE "Report an issue"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi modul v konfiguračnom móde";

--- a/airrohr-firmware/intl_tr.h
+++ b/airrohr-firmware/intl_tr.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "[[height_above_sealevel]]";
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "[[pressure_at_sealevel]]";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "yetkilendirme";
+const char INTL_NOPWD[] PROGMEM = "no WiFi password";
 #define INTL_REPORT_ISSUE "Sorun bildirin"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi Sensörü Yapılandırma modunda";

--- a/airrohr-firmware/intl_ua.h
+++ b/airrohr-firmware/intl_ua.h
@@ -42,6 +42,7 @@ const char INTL_HEIGHT_ABOVE_SEALEVEL[] PROGMEM = "Висота над рівн�
 const char INTL_PRESSURE_AT_SEALEVEL[] PROGMEM = "тиск на рівні моря";
 const char INTL_NEO6M[] PROGMEM = "GPS (NEO 6M)";
 const char INTL_BASICAUTH[] PROGMEM = "Авторизація";
+const char INTL_NOPWD[] PROGMEM = "без пароля WiFi";
 #define INTL_REPORT_ISSUE "Повідомте про проблему"
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi сенсор в режимі конфігурації";


### PR DESCRIPTION
please take this extension to my earlier freifunk fix (handling WiFi hotspot without passwords). From field usage, the earlier patch has shown to not cover the rare use cases: reconnect + switching from WPA AP to Hotspot AP. Fixed now.