### PR TITLE
Reduce the number of SDS011 errors

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -3481,7 +3481,7 @@ static void fetchSensorSDS(String &s)
 	}
 	else
 	{
-		if (!is_SDS_running)
+		if (!is_SDS_running || serialSDS.available() < SDS_waiting_for)
 		{
 			is_SDS_running = SDS_cmd(PmSensorCmd::Start);
 			SDS_waiting_for = SDS_REPLY_HDR;


### PR DESCRIPTION
On some sensors the number of SDS011 errors can be 5% or more resulting in noticeable gaps. This patch helps in reducing the number of SDS011 errors where the first SDS_cmd(PmSensorCmd::Start) fails and serialSDS.available() is less than what the loop expects. Instead of skipping the measurement the loop will retry to start.

This patch has been running on three different sensors with different power and network conditions for more than a year now with good results i.e. almost no SDS011 errors.

See https://forum.sensor.community/t/sds011-sends-zeroed-values/4590/25 for some background.