### PR TITLE
Alternative solution to avoid the sntp_time_set overflow

### DIFF
--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -634,7 +634,7 @@ unsigned long WiFi_error_count;
 unsigned long last_page_load = millis();
 
 bool wificonfig_loop = false;
-uint8_t sntp_time_set;
+uint16_t sntp_time_set;
 
 unsigned long count_sends = 0;
 unsigned long last_display_millis = 0;

--- a/airrohr-firmware/airrohr-firmware.ino
+++ b/airrohr-firmware/airrohr-firmware.ino
@@ -5779,10 +5779,7 @@ static void setupNetworkTime()
 							twoStageOTAUpdate();
 							last_update_attempt = millis();
 						}
-						if (sntp_time_set < 255)
-						{
-							sntp_time_set++;
-						}
+						sntp_time_set++;
 					});
 #endif
 	strcpy_P(ntpServer1, NTP_SERVER_1);


### PR DESCRIPTION
This is an alternative solution to sntp_time_set fix pull request #1057 from @mstv (BTW, I really liked those patches, most notably the trailing whitespace patch!).

Instead of maximising at 255 changing sntp_time_set to uint16_t allows for larger values. The maximum will be 672 (28 days runtime times 24 hours) so uint16 is enough.