### PR TITLE
Add missing Croatian patches (intl.h, platformio.ini)

### DIFF
--- a/airrohr-firmware/intl.h
+++ b/airrohr-firmware/intl.h
@@ -25,6 +25,8 @@
 #include "intl_fr.h"
 #elif defined(INTL_GR)
 #include "intl_gr.h"
+#elif defined(INTL_HR)
+#include "intl_hr.h"
 #elif defined(INTL_HU)
 #include "intl_hu.h"
 #elif defined(INTL_IT)

--- a/airrohr-firmware/platformio.ini
+++ b/airrohr-firmware/platformio.ini
@@ -265,6 +265,18 @@ build_flags = ${common.build_flags} -DINTL_GR
 lib_deps = ${common.lib_deps_esp8266}
 extra_scripts = ${common.extra_scripts}
 
+[env:nodemcuv2_hr]
+lang = hr
+platform = ${common.platform_version}
+framework = arduino
+board = nodemcuv2
+board_build.f_cpu = ${common.board_build.f_cpu}
+board_build.ldscript = ${common.board_build.ldscript}
+board_build.filesystem = ${common.board_build.filesystem}
+build_flags = ${common.build_flags} -DINTL_HR
+lib_deps = ${common.lib_deps_esp8266}
+extra_scripts = ${common.extra_scripts}
+
 [env:nodemcuv2_hu]
 lang = hu
 platform = ${common.platform_version}


### PR DESCRIPTION
These are needed to actually build the Croatian firmware. Copied from the master branch.